### PR TITLE
Mpm1

### DIFF
--- a/base/renderprogs/combineGbuffer.pixel
+++ b/base/renderprogs/combineGbuffer.pixel
@@ -52,16 +52,16 @@ float3 ColorCorrection(float3 color, float gamma)
 void main( PS_IN fragment, out PS_OUT result ) {
 	float2 tCoords = fragment.texcoord0;
 
-	float3 albedo = samp2.Sample(baseSampler, tCoords).rgb;// ColorCorrection(samp2.Sample(baseSampler, tCoords).rgb, 2.2); Mark fix so the color constrast is still as bold and our fringing isnt as sharp.
+	float3 albedo = samp2.Sample(baseSampler, tCoords).rgb;
 
-	float3 globalIllumination = samp4.Sample(baseSampler, tCoords).rgb * albedo;
+	float3 globalIllumination = samp4.Sample(baseSampler, tCoords).rgb;
 
-	float3 diffuse = samp0.Sample(baseSampler, tCoords).rgb * albedo;
+	float3 diffuse = (globalIllumination + samp0.Sample(baseSampler, tCoords).rgb) * albedo;
 	float3 specular = samp1.Sample(baseSampler, tCoords).rgb; // TODO: RValidate remving this is correct, now that we calculate it in the lighting. // * samp3.Sample(baseSampler, tCoords);
 
 	//specular.rgb = ColorCorrection(specular.rgb, 1.3); // Modifying our specular to better match the games style.
 	
-	result.color.rgb = saturate(globalIllumination + diffuse + specular); //TODO: move this to and HDR texture then have a separate shader to filter it down.
+	result.color.rgb = saturate(diffuse + specular); //TODO: move this to and HDR texture then have a separate shader to filter it down.
 	
 	result.color.w = 1.0;
 }

--- a/base/renderprogs/combineGbuffer.pixel
+++ b/base/renderprogs/combineGbuffer.pixel
@@ -52,7 +52,7 @@ float3 ColorCorrection(float3 color, float gamma)
 void main( PS_IN fragment, out PS_OUT result ) {
 	float2 tCoords = fragment.texcoord0;
 
-	float3 albedo = ColorCorrection(samp2.Sample(baseSampler, tCoords).rgb, 2.2);
+	float3 albedo = samp2.Sample(baseSampler, tCoords).rgb;// ColorCorrection(samp2.Sample(baseSampler, tCoords).rgb, 2.2); Mark fix so the color constrast is still as bold and our fringing isnt as sharp.
 
 	float3 globalIllumination = samp4.Sample(baseSampler, tCoords).rgb * albedo;
 

--- a/base/renderprogs/combineGbuffer.pixel
+++ b/base/renderprogs/combineGbuffer.pixel
@@ -52,16 +52,16 @@ float3 ColorCorrection(float3 color, float gamma)
 void main( PS_IN fragment, out PS_OUT result ) {
 	float2 tCoords = fragment.texcoord0;
 
-	float4 albedo = samp2.Sample(baseSampler, tCoords);
+	float3 albedo = ColorCorrection(samp2.Sample(baseSampler, tCoords).rgb, 2.2);
 
-	float4 globalIllumination = samp4.Sample(baseSampler, tCoords) * albedo;
+	float3 globalIllumination = samp4.Sample(baseSampler, tCoords).rgb * albedo;
 
-	float4 diffuse = samp0.Sample(baseSampler, tCoords) * albedo;
-	float4 specular = samp1.Sample(baseSampler, tCoords) * samp3.Sample(baseSampler, tCoords);
+	float3 diffuse = samp0.Sample(baseSampler, tCoords).rgb * albedo;
+	float3 specular = samp1.Sample(baseSampler, tCoords).rgb; // TODO: RValidate remving this is correct, now that we calculate it in the lighting. // * samp3.Sample(baseSampler, tCoords);
 
 	//specular.rgb = ColorCorrection(specular.rgb, 1.3); // Modifying our specular to better match the games style.
 	
-	result.color = saturate(globalIllumination + diffuse + specular); //TODO: move this to and HDR texture then have a separate shader to filter it down.
+	result.color.rgb = saturate(globalIllumination + diffuse + specular); //TODO: move this to and HDR texture then have a separate shader to filter it down.
 	
 	result.color.w = 1.0;
 }

--- a/base/renderprogs/functions.inc
+++ b/base/renderprogs/functions.inc
@@ -118,14 +118,17 @@ uint PackR8G8B8A8(float4 inputValue)
 // Material functions
 void ExtractMaterialProperties(
 	in float3 specularColor,
-	in float3 albedoColor,
+	in float3 materialProperties,
 	out float roughness,
-	out float3 baseReflection
+	out float3 baseReflection,
+	out float metalness
 )
 {
-	float glossiness = max(specularColor.r, max(specularColor.g, specularColor.b));
-	roughness = 1.0 - glossiness;
-	baseReflection = specularColor; // Suggested value based on 0.04 being the usual base reflectivene.
+	roughness = materialProperties.x;
+	metalness = materialProperties.y;
+
+	// Approximate the base reflectivity from the specular color.
+	baseReflection = specularColor;
 }
 
 // Lighting Helpers

--- a/base/renderprogs/functions.inc
+++ b/base/renderprogs/functions.inc
@@ -24,7 +24,7 @@ static const float4 matrixCoCg1YtoRGB1Z = float4( -1.0, -1.0,  1.00392156, 1.0 )
 static half3 ConvertDiffuseToAlbedo(in half3 rgbDiffuse)
 {
 	half3 albedoColor;
-	float invertLumminance = 1.0 - saturate(0.299 * rgbDiffuse.r + 0.587 * rgbDiffuse.g + 0.114 * rgbDiffuse.b);
+	float invertLumminance = 1.0 - saturate(0.299 * rgbDiffuse.r + 0.587 * rgbDiffuse.g + 0.114 * rgbDiffuse.b); //TODO: this works ok, but we need to keep finer details in the darks. maybe a cavity texture.
 	float L2 = 2.0 * invertLumminance;
 
 	if(invertLumminance < 0.5)

--- a/base/renderprogs/functions.inc
+++ b/base/renderprogs/functions.inc
@@ -21,6 +21,26 @@ static const float4 matrixCoCg1YtoRGB1X = float4(  1.0, -1.0,  0.0,        1.0 )
 static const float4 matrixCoCg1YtoRGB1Y = float4(  0.0,  1.0, -0.50196078, 1.0 ); // -0.5 * 256.0 / 255.0
 static const float4 matrixCoCg1YtoRGB1Z = float4( -1.0, -1.0,  1.00392156, 1.0 ); // +1.0 * 256.0 / 255.0
 
+static half3 ConvertDiffuseToAlbedo(in half3 rgbDiffuse)
+{
+	half3 albedoColor;
+	float invertLumminance = 1.0 - saturate(0.299 * rgbDiffuse.r + 0.587 * rgbDiffuse.g + 0.114 * rgbDiffuse.b);
+	float L2 = 2.0 * invertLumminance;
+
+	if(invertLumminance < 0.5)
+	{
+		albedoColor = (rgbDiffuse * L2) + pow(rgbDiffuse, 2.0) * (1.0 - L2);
+	}
+	else
+	{
+		albedoColor = (2.0 * rgbDiffuse * (1.0 - invertLumminance)) + (sqrt(rgbDiffuse) * (2.0 * invertLumminance - 1.0));
+	}
+
+	//albedoColor = ((1.0 - L2) * pow(rgbDiffuse, 2.0)) + (L2 * rgbDiffuse);
+
+	return albedoColor;
+}
+
 static half3 ConvertYCoCgToRGB( half4 YCoCg ) {
 	half3 rgbColor;
 
@@ -128,7 +148,7 @@ void ExtractMaterialProperties(
 	metalness = materialProperties.y;
 
 	// Approximate the base reflectivity from the specular color.
-	baseReflection = specularColor;
+	baseReflection = specularColor * materialProperties.z;
 }
 
 // Lighting Helpers

--- a/base/renderprogs/functions.inc
+++ b/base/renderprogs/functions.inc
@@ -114,3 +114,22 @@ uint PackR8G8B8A8(float4 inputValue)
 
 	return ((values.x & 0xFF) << 24) | ((values.y & 0xFF) << 16) | ((values.z & 0xFF) << 8) | (values.w & 0xFF);
 }
+
+// Material functions
+void ExtractMaterialProperties(
+	in float3 specularColor,
+	in float3 albedoColor,
+	out float roughness,
+	out float3 baseReflection
+)
+{
+	float glossiness = max(specularColor.r, max(specularColor.g, specularColor.b));
+	roughness = 1.0 - glossiness;
+	baseReflection = specularColor; // Suggested value based on 0.04 being the usual base reflectivene.
+}
+
+// Lighting Helpers
+inline float3 CalculateFresnel(in float3 baseReflectivity, in float3 viewVector, in float3 halfVector)
+{
+	return baseReflectivity + (1.0 - baseReflectivity) * pow(1.0 - dot3(viewVector, halfVector), 5.0);
+}

--- a/base/renderprogs/gbuffer.inc
+++ b/base/renderprogs/gbuffer.inc
@@ -196,10 +196,10 @@ struct PS_OUT {
 #endif
 	half4 albedo		: SV_TARGET3;
 	half4 specularColor	: SV_TARGET4;
+	half4 materialProps	: SV_TARGET5;
 #ifdef WRITE_VELOCITY
-	float4 velocity		: SV_TARGET5;
+	float4 velocity		: SV_TARGET6;
 #endif
-	half4 materialProps	: SV_TARGET6;
 };
 
 #ifdef WRITE_VELOCITY
@@ -228,8 +228,8 @@ void main( PS_IN fragment, out PS_OUT result ) {
 	float3 reflectivity;
 	float roughness;
 
-	ExtractMaterialProperties(result.specularColor, result.albedo, roughness, reflectivity);
-	result.materialProps.rgb = half3(roughness, 0.0f, 0.0f);
+	//ExtractMaterialProperties(result.specularColor, result.albedo, roughness, reflectivity);
+	result.materialProps = sceneConstants.rpMaterialProperties;
 
 #ifdef WRITE_VELOCITY
 	result.velocity = CalculateVelocity(fragment.lastPosition, fragment.position);

--- a/base/renderprogs/gbuffer.inc
+++ b/base/renderprogs/gbuffer.inc
@@ -223,7 +223,7 @@ void main( PS_IN fragment, out PS_OUT result ) {
 	
 	result.specularColor = SampleBindlessTexture4f(gbufferConstants.specularIndex, fragment.texcoord2.xy );
 	
-	result.albedo.rgb = ConvertYCoCgToRGB( YCoCG ); //we need the diffuse modifier constant?
+	result.albedo.rgb = ConvertDiffuseToAlbedo(ConvertYCoCgToRGB( YCoCG )); //we need the diffuse modifier constant?
 
 	float3 reflectivity;
 	float roughness;

--- a/base/renderprogs/gbuffer.inc
+++ b/base/renderprogs/gbuffer.inc
@@ -191,14 +191,15 @@ struct PS_IN {
 struct PS_OUT {
 #ifdef WRITE_LOCATION_DATA
 	half3 flatNormal	: SV_TARGET0;
-	float3 viewDepth	: SV_TARGET1;
-	half3 normal		: SV_TARGET2;
+	half3 flatTangent	: SV_TARGET1;
+	float3 viewDepth	: SV_TARGET2;
+	half3 normal		: SV_TARGET3;
 #endif
-	half4 albedo		: SV_TARGET3;
-	half4 specularColor	: SV_TARGET4;
-	half4 materialProps	: SV_TARGET5;
+	half4 albedo		: SV_TARGET4;
+	half4 specularColor	: SV_TARGET5;
+	half4 materialProps	: SV_TARGET6;
 #ifdef WRITE_VELOCITY
-	float4 velocity		: SV_TARGET6;
+	float4 velocity		: SV_TARGET7;
 #endif
 };
 
@@ -239,6 +240,7 @@ void main( PS_IN fragment, out PS_OUT result ) {
 	result.viewDepth = fragment.viewPosition.xyz;//length(fragment.viewPosition.xyz);// / fragment.viewPosition.w); // The depth going into the view space. Note, z will be negitive
 
 	result.flatNormal = (normalize(fragment.normal) + 1.0) / 2.0f;
+	result.flatTangent = (normalize(fragment.tangent) + 1.0) / 2.0f;
 
 	half3 localNormal;
 	localNormal.xy = bumpMap.wy - 0.5;

--- a/base/renderprogs/gbuffer.inc
+++ b/base/renderprogs/gbuffer.inc
@@ -199,6 +199,7 @@ struct PS_OUT {
 #ifdef WRITE_VELOCITY
 	float4 velocity		: SV_TARGET5;
 #endif
+	half4 materialProps	: SV_TARGET6;
 };
 
 #ifdef WRITE_VELOCITY
@@ -223,6 +224,12 @@ void main( PS_IN fragment, out PS_OUT result ) {
 	result.specularColor = SampleBindlessTexture4f(gbufferConstants.specularIndex, fragment.texcoord2.xy );
 	
 	result.albedo.rgb = ConvertYCoCgToRGB( YCoCG ); //we need the diffuse modifier constant?
+
+	float3 reflectivity;
+	float roughness;
+
+	ExtractMaterialProperties(result.specularColor, result.albedo, roughness, reflectivity);
+	result.materialProps.rgb = half3(roughness, 0.0f, 0.0f);
 
 #ifdef WRITE_VELOCITY
 	result.velocity = CalculateVelocity(fragment.lastPosition, fragment.position);

--- a/base/renderprogs/global.inc
+++ b/base/renderprogs/global.inc
@@ -106,6 +106,9 @@ struct SceneConstants {
 	float4 rpEnableSkinning;
 	float4 rpAlphaTest;
 
+	float4 rpMaterialProperties;
+
+	// Not yet setup
 	float4 rpPrevMVPmatrixX;
 	float4 rpPrevMVPmatrixY;
 	float4 rpPrevMVPmatrixZ;

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -222,7 +222,7 @@ float3 CalculateProjection(in SceneLight light, float4 worldPosition)
 
 	projection.xy /= projection.w;
 
-	return pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
+	return SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb;//pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
 }
 
 uint4 ConvertShadowmapMaskToVector(uint shadowMask)
@@ -250,20 +250,21 @@ float StartDistanceFromSurface(in float3 worldPosition, in float3 eyePosition)
 // Light functions
 // General BRDF functions
 void GeneralBRDF(
-    float3 lightColor,
-    float NdotL,
-    float3 surfaceNormal,
-    float baseReflectivity, //TODO: Add this as a material property to the surface.
-    float roughness, //TODO: Add this as a material property to the surface.
-    float3 viewVector,
-    float3 halfVector,
+    in float3 lightColor,
+    in float NdotL,
+    in float3 surfaceNormal,
+    in float distribution, // The integral value over the surface for the light. This should usually be PI, but for our raytracing we'll set this to 1.0 and devide by the sample count later.'
+    in float baseReflectivity, //TODO: Add this as a material property to the surface.
+    in float roughness, //TODO: Add this as a material property to the surface.
+    in float3 viewVector,
+    in float3 halfVector,
     out float3 diffuseContribution,
     out float3 specularContribution)
 {
     float fresnelFactor = baseReflectivity + (1.0 - baseReflectivity) * pow(1.0 - dot3(viewVector, halfVector), 5.0);
 
     // Diffuse using the Lambertian Model (we already used L dot N for the light Color)
-    diffuseContribution = (lightColor * NdotL * (1.0 - fresnelFactor)) / PI;
+    diffuseContribution = (lightColor * NdotL * (1.0 - fresnelFactor)) / distribution;
 
     // Useing Cook-Torrance BRDF for specular reflection
     float NdotH = max(dot3(surfaceNormal, halfVector), 0.0);
@@ -272,7 +273,7 @@ void GeneralBRDF(
     float k = alpha / 2.0;
 
     float a2 = alpha * alpha;
-    float D = a2 / (PI * pow(NdotH * NdotH * (a2 - 1.0) + 1.0, 2.0)); // DGGX Trowbridge-Reitz distribution
+    float D = a2 / (distribution * pow(NdotH * NdotH * (a2 - 1.0) + 1.0, 2.0)); // DGGX Trowbridge-Reitz distribution
 
     float NdotV = max(dot(surfaceNormal, viewVector), 0.0);
     float G1 = NdotV / (NdotV * (1 - k) + k);
@@ -290,8 +291,9 @@ float CalcluateLightImpact(
     in float3 viewVector, // Hit point to eye vector.
     in float3 surfaceNormal,
     in float3 lightVector,
-    float baseReflectivity, //TODO: Add this as a material property to the surface.
-    float roughness, //TODO: Add this as a material property to the surface.
+    in float distribution, // The integral value over the surface for the light. This should usually be PI, but for our raytracing we'll set this to 1.0 and devide by the sample count later.'
+    in float baseReflectivity, //TODO: Add this as a material property to the surface.
+    in float roughness, //TODO: Add this as a material property to the surface.
     out float3 diffuseContribution,
     out float3 specularContribution
     )
@@ -300,7 +302,7 @@ float CalcluateLightImpact(
 
     // TODO: Do we need a modifier here for subsurface scattering?
 
-    if (NdotL <= EPSILON)
+    if (NdotL <= 0.0)
 	{
 		// No light is being cast.
         diffuseContribution = float3(0.0f, 0.0f, 0.0f);
@@ -312,7 +314,7 @@ float CalcluateLightImpact(
                 CalculateFalloff(light, float4(worldPosition, 1.0)) * 
 				CalculateProjection(light, float4(worldPosition, 1.0));
 
-    if (length(lightColor) <= EPSILON)
+    if (length(lightColor) <= 0.0)
     {
         // No light is reflected.
         diffuseContribution = float3(0.0f, 0.0f, 0.0f);
@@ -324,6 +326,7 @@ float CalcluateLightImpact(
         lightColor,
         NdotL,
         surfaceNormal,
+        distribution,
         baseReflectivity, // Base reflectivity, we need to eventually adjust this per material.
         roughness, // Roughness, we need to eventually adjust this per material.
         viewVector, // View vector

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -78,7 +78,8 @@ struct SceneLight {
     uint    pad2;
     float   emissiveRadius;
 
-    float4   color;
+    float4   diffuseColor;
+    float4   specularColor;
 
     float4  center;
     
@@ -265,6 +266,8 @@ float StartDistanceFromSurface(in float3 worldPosition, in float3 eyePosition)
 // General BRDF functions
 void GeneralBRDF(
     in float3 lightColor,
+    in float3 diffuseColor,
+    in float3 specularColor,
     in float NdotL,
     in float3 surfaceNormal,
     in float distribution, // The integral value over the surface for the light. This should usually be PI, but for our raytracing we'll set this to 1.0 and devide by the sample count later.'
@@ -278,7 +281,7 @@ void GeneralBRDF(
     float3 fresnelFactor = CalculateFresnel(baseReflectivity, viewVector, halfVector);
 
     // Diffuse using the Lambertian Model (we already used L dot N for the light Color)
-    diffuseContribution = (lightColor * NdotL * (1.0 - fresnelFactor)) / distribution;
+    diffuseContribution = lightColor * (diffuseColor * NdotL * (1.0 - fresnelFactor)) / distribution;
 
     // Useing Cook-Torrance BRDF for specular reflection
     float NdotH = max(dot3(surfaceNormal, halfVector), 0.0);
@@ -300,7 +303,7 @@ void GeneralBRDF(
         return;  
     }
 
-    specularContribution = lightColor * ((D * G * fresnelFactor) / (4.0 * NdotL * NdotV));
+    specularContribution = lightColor * specularColor * ((D * G * fresnelFactor) / (4.0 * NdotL * NdotV));
 }
 
 // Calculates the amount of specular and diffuse light hitting a surface.
@@ -331,7 +334,7 @@ float CalcluateLightImpact(
 		return NdotL;
 	}
 
-    float3 lightColor = light.color.rgb *
+    float3 lightColor = 
                 CalculateFalloff(light, float4(lightWorldPosition, 1.0)) *
 				CalculateProjection(light, float4(lightWorldPosition, 1.0));
 
@@ -345,6 +348,8 @@ float CalcluateLightImpact(
 
     GeneralBRDF(
         lightColor,
+        light.diffuseColor.rgb,
+        light.specularColor.rgb,
         NdotL,
         surfaceNormal,
         distribution,

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -222,7 +222,7 @@ float3 CalculateProjection(in SceneLight light, float4 worldPosition)
 
 	projection.xy /= projection.w;
 
-	return pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 3.2); // Added some correction to match the original art
+	return pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
 }
 
 uint4 ConvertShadowmapMaskToVector(uint shadowMask)
@@ -263,10 +263,10 @@ void GeneralBRDF(
     float fresnelFactor = baseReflectivity + (1.0 - baseReflectivity) * pow(1.0 - dot3(viewVector, halfVector), 5.0);
 
     // Diffuse using the Lambertian Model (we already used L dot N for the light Color)
-    diffuseContribution = lightColor * (1.0 - fresnelFactor) / PI;
+    diffuseContribution = (lightColor * NdotL * (1.0 - fresnelFactor)) / PI;
 
     // Useing Cook-Torrance BRDF for specular reflection
-    float NdotH = dot3(surfaceNormal, halfVector);
+    float NdotH = max(dot3(surfaceNormal, halfVector), 0.0);
 
     float alpha = roughness * roughness;
     float k = alpha / 2.0;
@@ -274,12 +274,12 @@ void GeneralBRDF(
     float a2 = alpha * alpha;
     float D = a2 / (PI * pow(NdotH * NdotH * (a2 - 1.0) + 1.0, 2.0)); // DGGX Trowbridge-Reitz distribution
 
-    float NdotV = dot(surfaceNormal, viewVector);
+    float NdotV = max(dot(surfaceNormal, viewVector), 0.0);
     float G1 = NdotV / (NdotV * (1 - k) + k);
-    float G2 = lightColor / (NdotL * (1 - k) + k);
+    float G2 = NdotL / (NdotL * (1 - k) + k);
     float G = G1 * G2; // Smith's shadowing-masking function
 
-    specularContribution = (D * G * fresnelFactor) / (4.0 * NdotL * NdotV);
+    specularContribution = lightColor * ((D * G * fresnelFactor) / (4.0 * NdotL * NdotV));
 }
 
 // Calculates the amount of specular and diffuse light hitting a surface.
@@ -290,6 +290,8 @@ float CalcluateLightImpact(
     in float3 viewVector, // Hit point to eye vector.
     in float3 surfaceNormal,
     in float3 lightVector,
+    float baseReflectivity, //TODO: Add this as a material property to the surface.
+    float roughness, //TODO: Add this as a material property to the surface.
     out float3 diffuseContribution,
     out float3 specularContribution
     )
@@ -306,8 +308,8 @@ float CalcluateLightImpact(
 		return NdotL;
 	}
 
-    float3 lightColor = NdotL * 
-				CalculateFalloff(light, float4(worldPosition, 1.0)) * 
+    float3 lightColor = 
+                CalculateFalloff(light, float4(worldPosition, 1.0)) * 
 				CalculateProjection(light, float4(worldPosition, 1.0));
 
     if (length(lightColor) <= EPSILON)
@@ -322,8 +324,8 @@ float CalcluateLightImpact(
         lightColor,
         NdotL,
         surfaceNormal,
-        0.5f, // Base reflectivity, we need to eventually adjust this per material.
-        0.5f, // Roughness, we need to eventually adjust this per material.
+        baseReflectivity, // Base reflectivity, we need to eventually adjust this per material.
+        roughness, // Roughness, we need to eventually adjust this per material.
         viewVector, // View vector
         normalize(lightVector + viewVector), // Half vector
         diffuseContribution,

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -57,10 +57,10 @@ struct Attributes
   float2	location; // Location of the hit.
 };
 
-#define LIGHT_FLAG_CASTS_SHADOWS (0x01 << 0)
-#define LIGHT_FLAG_POINT_LIGHT   (0x01 << 1)
-#define LIGHT_FLAG_AMBIENT_LIGHT (0x01 << 2)
-#define LIGHT_FLAG_FOG_LIGHT     (0x01 << 3)
+#define LIGHT_FLAG_CASTS_SHADOWS (0x0001 << 0)
+#define LIGHT_FLAG_POINT_LIGHT   (0x0001 << 1)
+#define LIGHT_FLAG_AMBIENT_LIGHT (0x0001 << 2)
+#define LIGHT_FLAG_FOG_LIGHT     (0x0001 << 3)
 
 #define MAX_SCENE_LIGHTS 128
 
@@ -74,7 +74,7 @@ struct SceneLight {
     uint    projectionIndex;
 
     uint    flags;
-    uint    pad1;
+    float   shadowStartDistance; // Distance from the light to start the shadow casting. 
     uint    pad2;
     float   emissiveRadius;
 
@@ -123,7 +123,7 @@ struct RaytracedSceneConstants {
     uint raysPerLight;
 
     float noiseOffset;
-	uint pad0;
+	uint flatTangentIndex;
 	uint pad1;
 	uint pad2;
 };
@@ -210,24 +210,33 @@ inline float4 GetWorldPointFromDepth(float depth, float2 screenPosition, in Rayt
 
 float3 CalculateFalloff(in SceneLight light, float4 worldPosition)
 {
-	float2 uv = float2(dot4( worldPosition, light.falloffS ), 0);
-	float4 falloff =  SampleBindlessTexture4fLevel(light.falloffIndex, uv, 0);
-	
+	float4 uv = dot4( worldPosition, light.falloffS );
+	float4 falloff =  SampleBindlessTexture4fLevel(light.falloffIndex, uv.xy, 0);
+
 	return falloff.rgb;
 }
 
-float3 CalculateProjection(in SceneLight light, float4 worldPosition)
+float3 GetLightSpacePosition(in SceneLight light,  in float3 worldPosition)
+{
+    // Given a light, calculate the position of the point with respect to the light in the world.
+    //float3 location = worldPosition.xyz - light.center; //TODO: Realign the light to match the perspective angle of the point
+   
+    //return location;
+    return worldPosition;
+}
+
+float3 CalculateProjection(in SceneLight light, in float4 location)
 {
 	float4 projection = float4(
-		dot4(worldPosition, light.projectionS),
-		dot4(worldPosition, light.projectionT),
+		dot4(location, light.projectionS),
+		dot4(location, light.projectionT),
 		0.0f,
-		dot4(worldPosition, light.projectionQ)
+		dot4(location, light.projectionQ)
 	);
 
-	projection.xy /= projection.w;
-
-	return SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb;//pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
+	projection.xy /= projection.w; //This is done to match idtex2Dproj
+    
+	return SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 1).rgb;//pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
 }
 
 uint4 ConvertShadowmapMaskToVector(uint shadowMask)
@@ -310,6 +319,7 @@ float CalcluateLightImpact(
     )
 {
     float NdotL = dot3(surfaceNormal, lightVector);
+    float3 lightWorldPosition = GetLightSpacePosition(light, worldPosition);
 
     // TODO: Do we need a modifier here for subsurface scattering?
 
@@ -322,8 +332,8 @@ float CalcluateLightImpact(
 	}
 
     float3 lightColor = light.color.rgb *
-                CalculateFalloff(light, float4(worldPosition, 1.0)) * 
-				CalculateProjection(light, float4(worldPosition, 1.0));
+                CalculateFalloff(light, float4(lightWorldPosition, 1.0)) *
+				CalculateProjection(light, float4(lightWorldPosition, 1.0));
 
     if (length(lightColor) <= 0.0)
     {

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -113,14 +113,19 @@ struct RaytracedSceneConstants {
     RenderParameters rp;
 
     uint lightCount;
-    float noiseOffset;
     uint diffuseTextureIndex;
     uint specularTexureIndex;
+    uint materialTextureIndex;
 
     uint positionTextureIndex;
 	uint flatNormalIndex;
     uint normalIndex;
     uint raysPerLight;
+
+    float noiseOffset;
+	uint pad0;
+	uint pad1;
+	uint pad2;
 };
 
 // Raytracing acceleration structure, accessed as a SRV
@@ -316,7 +321,7 @@ float CalcluateLightImpact(
 		return NdotL;
 	}
 
-    float3 lightColor = 
+    float3 lightColor = light.color.rgb *
                 CalculateFalloff(light, float4(worldPosition, 1.0)) * 
 				CalculateProjection(light, float4(worldPosition, 1.0));
 

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -234,7 +234,7 @@ float3 CalculateProjection(in SceneLight light, in float4 location)
 		dot4(location, light.projectionQ)
 	);
 
-	projection.xy /= projection.w; //This is done to match idtex2Dproj
+    projection.xy /= projection.w; //This is done to match idtex2Dproj
     
 	return SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 1).rgb;//pow(SampleBindlessTexture4fLevel(light.projectionIndex, projection.xy, 0).rgb, 1 / 2.2); // Added some correction to match the original art
 }

--- a/base/renderprogs/raytracing_global.inc
+++ b/base/renderprogs/raytracing_global.inc
@@ -254,14 +254,14 @@ void GeneralBRDF(
     in float NdotL,
     in float3 surfaceNormal,
     in float distribution, // The integral value over the surface for the light. This should usually be PI, but for our raytracing we'll set this to 1.0 and devide by the sample count later.'
-    in float baseReflectivity, //TODO: Add this as a material property to the surface.
+    in float3 baseReflectivity, //TODO: Add this as a material property to the surface.
     in float roughness, //TODO: Add this as a material property to the surface.
     in float3 viewVector,
     in float3 halfVector,
     out float3 diffuseContribution,
     out float3 specularContribution)
 {
-    float fresnelFactor = baseReflectivity + (1.0 - baseReflectivity) * pow(1.0 - dot3(viewVector, halfVector), 5.0);
+    float3 fresnelFactor = CalculateFresnel(baseReflectivity, viewVector, halfVector);
 
     // Diffuse using the Lambertian Model (we already used L dot N for the light Color)
     diffuseContribution = (lightColor * NdotL * (1.0 - fresnelFactor)) / distribution;
@@ -276,9 +276,15 @@ void GeneralBRDF(
     float D = a2 / (distribution * pow(NdotH * NdotH * (a2 - 1.0) + 1.0, 2.0)); // DGGX Trowbridge-Reitz distribution
 
     float NdotV = max(dot(surfaceNormal, viewVector), 0.0);
-    float G1 = NdotV / (NdotV * (1 - k) + k);
-    float G2 = NdotL / (NdotL * (1 - k) + k);
+    float G1 = NdotV / max(NdotV * (1 - k) + k, 0.0000001);
+    float G2 = NdotL / max(NdotL * (1 - k) + k, 0.0000001);
     float G = G1 * G2; // Smith's shadowing-masking function
+
+    if(G <= 0.0)
+    {
+        specularContribution = float3(0.0f, 0.0f, 0.0f);
+        return;  
+    }
 
     specularContribution = lightColor * ((D * G * fresnelFactor) / (4.0 * NdotL * NdotV));
 }
@@ -292,7 +298,7 @@ float CalcluateLightImpact(
     in float3 surfaceNormal,
     in float3 lightVector,
     in float distribution, // The integral value over the surface for the light. This should usually be PI, but for our raytracing we'll set this to 1.0 and devide by the sample count later.'
-    in float baseReflectivity, //TODO: Add this as a material property to the surface.
+    in float3 baseReflectivity, //TODO: Add this as a material property to the surface.
     in float roughness, //TODO: Add this as a material property to the surface.
     out float3 diffuseContribution,
     out float3 specularContribution

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -120,12 +120,13 @@ void HandlePointLight(
 			pointToEye,
 			normal,
 			lightVector,
+			1.0, // Since we divide by our count later, we can just use 1.0 here. Original algorithm calls for PI
 			baseReflection,
 			roughness,
 			localDiffuse,
 			localSpecular);
 
-		if (intensity <= EPSILON)
+		if (intensity <= 0.0)
 		{
 			// No light is being cast.
 			continue;

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -35,7 +35,7 @@ float3 GetSpecularResult(in SceneLight light, in float3 lightFalloff, in float3 
 	half hDotN = dot3(normalize(pointToEye + pointToLight), normal);
 	half3 specularContribution = _half3(pow( hDotN, specularPower ));
 
-	return specularContribution * (light.color.rgb * specMultiplier) * lightFalloff.rgb;
+	return specularContribution * (light.specularColor.rgb * specMultiplier) * lightFalloff.rgb;
 }
 
 float3 GetValidLightLocation(in SceneLight light, in Plane surfacePlane, in float3 randomOffset)
@@ -76,7 +76,7 @@ void HandleAmbientLight(
 			CalculateProjection(light, float4(worldPosition, 1.0));
 	}
 
-	diffuseResult = light.color.rgb * lightColor.rgb;
+	diffuseResult = light.diffuseColor.rgb * lightColor.rgb;
 	specularResult = GetSpecularResult(light, lightColor, normal, pointToEye, lightVector, 2.0 /* Keeping consistant original method */);
 }
 

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -15,6 +15,18 @@ bool IsInsideViewport(float2 p, float4 viewport)
 		&& (p.y >= viewport.y && p.y <= viewport.w);
 }
 
+void ExtractMaterialProperties(
+	in float2 screenUV,
+	out float roughness,
+	out float baseReflection)
+{
+	float3 specular = GetBindlessTexture4f(sceneConstants.specularTexureIndex).SampleLevel(pointSampler, screenUV.xy, 0).rgb;
+
+	float glossiness = max(specular.r, max(specular.g, specular.b));
+	roughness = 1.0 - glossiness;
+	baseReflection = 0.04 + (0.96 * glossiness); // Suggested value based on 0.04 being the usual base reflectivene.
+}
+
 float3 GetSpecularResult(in SceneLight light, in float3 lightFalloff, in float3 normal, in float3 pointToEye, in float3 pointToLight, in float specMultiplier)
 {
 	const half specularPower = 10.0f;
@@ -82,6 +94,10 @@ void HandlePointLight(
 	diffuseResult = float3(0.0, 0.0, 0.0);
 	specularResult = float3(0.0, 0.0, 0.0);
 
+	float baseReflection;
+	float roughness;
+	ExtractMaterialProperties(screenUV, roughness, baseReflection);
+
 	float3 pointToCenter = normalize(light.center - worldPosition);
 
 	for(uint rayIndex = 0; rayIndex < lightRayCount; ++rayIndex)
@@ -104,6 +120,8 @@ void HandlePointLight(
 			pointToEye,
 			normal,
 			lightVector,
+			baseReflection,
+			roughness,
 			localDiffuse,
 			localSpecular);
 

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -15,16 +15,16 @@ bool IsInsideViewport(float2 p, float4 viewport)
 		&& (p.y >= viewport.y && p.y <= viewport.w);
 }
 
-void ExtractMaterialProperties(
+void ExtractMaterialPropertiesFromGBuffer(
 	in float2 screenUV,
 	out float roughness,
-	out float baseReflection)
+	out float3 baseReflection)
 {
 	float3 specular = GetBindlessTexture4f(sceneConstants.specularTexureIndex).SampleLevel(pointSampler, screenUV.xy, 0).rgb;
 
-	float glossiness = max(specular.r, max(specular.g, specular.b));
-	roughness = 1.0 - glossiness;
-	baseReflection = 0.04 + (0.96 * glossiness); // Suggested value based on 0.04 being the usual base reflectivene.
+	ExtractMaterialProperties(
+	specular, float3(0.0, 0.0, 0.0),
+	roughness, baseReflection);
 }
 
 float3 GetSpecularResult(in SceneLight light, in float3 lightFalloff, in float3 normal, in float3 pointToEye, in float3 pointToLight, in float specMultiplier)
@@ -94,9 +94,9 @@ void HandlePointLight(
 	diffuseResult = float3(0.0, 0.0, 0.0);
 	specularResult = float3(0.0, 0.0, 0.0);
 
-	float baseReflection;
+	float3 baseReflection;
 	float roughness;
-	ExtractMaterialProperties(screenUV, roughness, baseReflection);
+	ExtractMaterialPropertiesFromGBuffer(screenUV, roughness, baseReflection);
 
 	float3 pointToCenter = normalize(light.center - worldPosition);
 
@@ -133,15 +133,15 @@ void HandlePointLight(
 		}
 		
 		if(castsShadows)
-		{
+		{ 
 			RayQuery<RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH> inlineQuery;
 
 			// We are inside the light radius.
 			// Define a ray, consisting of origin, direction, and the min-max distance values
 			RayDesc ray;
-			ray.TMin = rayStartDistance;
+			ray.TMin = 0.0001;
 			ray.TMax = maxDistance;
-			ray.Origin = worldPosition;
+			ray.Origin = worldPosition + (normal * rayStartDistance);
 			ray.Direction = lightVector;
 
 			inlineQuery.TraceRayInline(

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -137,7 +137,7 @@ void HandlePointLight(
 					normalize(float3(screenUV.xy + float2(light.sceneIndex, rayIndex) + sceneConstants.noiseOffset, rayIndex + light.sceneIndex))
 					);
 
-			float maxDistance = distance(shadowLightPosition, worldPosition);
+			float maxDistance = distance(shadowLightPosition, worldPosition) - light.shadowStartDistance;
 			float3 shadowLightVector = normalize(shadowLightPosition - worldPosition);
 
 			RayQuery<RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH> inlineQuery;
@@ -196,7 +196,11 @@ void RayGen() {
 	screenUV.y = 1.0 - screenUV.y;
 	
 	float3 worldPosition = GetBindlessTexture4f(sceneConstants.positionTextureIndex).SampleLevel(pointSampler, screenUV.xy, 0).xyz;
+
 	float3 flatNormal = normalize((GetBindlessTexture4f(sceneConstants.flatNormalIndex).SampleLevel(pointSampler, screenUV.xy, 0).xyz * 2.0) - 1.0);
+	float3 flatTangent = normalize((GetBindlessTexture4f(sceneConstants.flatTangentIndex).SampleLevel(pointSampler, screenUV.xy, 0).xyz * 2.0) - 1.0);
+	float3 flatBinormal = normalize(cross(flatNormal, flatTangent));
+
 	float3 normal = normalize((GetBindlessTexture4f(sceneConstants.normalIndex).SampleLevel(pointSampler, screenUV.xy, 0).xyz * 2.0) - 1.0);
 
 	// Calculate the offset from the ray start we'd like to use.

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -18,13 +18,15 @@ bool IsInsideViewport(float2 p, float4 viewport)
 void ExtractMaterialPropertiesFromGBuffer(
 	in float2 screenUV,
 	out float roughness,
-	out float3 baseReflection)
+	out float3 baseReflection,
+	out float metalness)
 {
 	float3 specular = GetBindlessTexture4f(sceneConstants.specularTexureIndex).SampleLevel(pointSampler, screenUV.xy, 0).rgb;
+	float3 materialProperties = GetBindlessTexture4f(sceneConstants.materialTextureIndex).SampleLevel(pointSampler, screenUV.xy, 0).rgb;
 
 	ExtractMaterialProperties(
-	specular, float3(0.0, 0.0, 0.0),
-	roughness, baseReflection);
+	specular, materialProperties,
+	roughness, baseReflection, metalness);
 }
 
 float3 GetSpecularResult(in SceneLight light, in float3 lightFalloff, in float3 normal, in float3 pointToEye, in float3 pointToLight, in float specMultiplier)
@@ -94,9 +96,16 @@ void HandlePointLight(
 	diffuseResult = float3(0.0, 0.0, 0.0);
 	specularResult = float3(0.0, 0.0, 0.0);
 
+	if(isnan(worldPosition.x) || isnan(worldPosition.y) || isnan(worldPosition.z))
+	{
+		// Invalid world position
+		return;
+	}
+
 	float3 baseReflection;
 	float roughness;
-	ExtractMaterialPropertiesFromGBuffer(screenUV, roughness, baseReflection);
+	float metalness;
+	ExtractMaterialPropertiesFromGBuffer(screenUV, roughness, baseReflection, metalness);
 
 	float3 pointToCenter = normalize(light.center - worldPosition);
 
@@ -111,6 +120,12 @@ void HandlePointLight(
 
 		float maxDistance = distance(lightPosition, worldPosition);
 		float3 lightVector = normalize(lightPosition - worldPosition);
+
+		if(isnan(lightVector.x) || isnan(lightVector.y) || isnan(lightVector.z))
+		{
+			// Invalid light position
+			continue;
+		}
 
 		float3 localDiffuse = float3(0.0, 0.0, 0.0);
 		float3 localSpecular = float3(0.0, 0.0, 0.0);
@@ -140,16 +155,21 @@ void HandlePointLight(
 			// Define a ray, consisting of origin, direction, and the min-max distance values
 			RayDesc ray;
 			ray.TMin = 0.0001;
-			ray.TMax = maxDistance;
+			ray.TMax = maxDistance - ray.TMin;
 			ray.Origin = worldPosition + (normal * rayStartDistance);
 			ray.Direction = lightVector;
+
+			if(ray.TMin >= ray.TMax)
+			{
+				// Ray is too short to trace.
+				continue;
+			}
 
 			inlineQuery.TraceRayInline(
 				SceneBVH,
 				RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, // OR'd with flags above
 				INSTANCE_MASK_CAST_SHADOW, // Only cast against shadow casting objects.
 				ray);
-
 			inlineQuery.Proceed(); // Run the tracer.
 				
 			if(inlineQuery.CommittedStatus() == COMMITTED_TRIANGLE_HIT)
@@ -188,7 +208,7 @@ void RayGen() {
 
 	// Calculate the offset from the ray start we'd like to use.
 	// This is done to help with precision errors the further away our surface is.
-	float rayStartDistance = StartDistanceFromSurface(worldPosition, sceneConstants.rp.globalEyePos.xyz);
+	float rayStartDistance = 0.001; //StartDistanceFromSurface(worldPosition, sceneConstants.rp.globalEyePos.xyz);
 	
 	float3 pointToEye = normalize(sceneConstants.rp.globalEyePos.xyz - worldPosition);
 

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -109,55 +109,46 @@ void HandlePointLight(
 
 	float3 pointToCenter = normalize(light.center - worldPosition);
 
-	for(uint rayIndex = 0; rayIndex < lightRayCount; ++rayIndex)
+	// We'll keep the lights as a point and only the shadows are affected by the light radius.
+	float3 lightPosition = light.center;
+	float3 lightVector = normalize(lightPosition - worldPosition);
+
+	float intensity = CalcluateLightImpact(
+		light,
+		worldPosition,
+		pointToEye,
+		normal,
+		lightVector,
+		PI, // Since we divide by our count later, we can just use 1.0 here. Original algorithm calls for PI
+		baseReflection,
+		roughness,
+		diffuseResult,
+		specularResult);
+
+	if(intensity > 0.0 && castsShadows)
 	{
-		float3 lightPosition = castsShadows ?
-			GetValidLightLocation(
-				light, surfacePlane,
-				normalize(float3(screenUV.xy + float2(light.sceneIndex, rayIndex) + sceneConstants.noiseOffset, rayIndex + light.sceneIndex))
-				)
-			: light.center;
-
-		float maxDistance = distance(lightPosition, worldPosition);
-		float3 lightVector = normalize(lightPosition - worldPosition);
-
-		if(isnan(lightVector.x) || isnan(lightVector.y) || isnan(lightVector.z))
-		{
-			// Invalid light position
-			continue;
-		}
-
-		float3 localDiffuse = float3(0.0, 0.0, 0.0);
-		float3 localSpecular = float3(0.0, 0.0, 0.0);
-		float intensity = CalcluateLightImpact(
-			light,
-			worldPosition,
-			pointToEye,
-			normal,
-			lightVector,
-			PI, // Since we divide by our count later, we can just use 1.0 here. Original algorithm calls for PI
-			baseReflection,
-			roughness,
-			localDiffuse,
-			localSpecular);
-
-		if (intensity <= 0.0)
-		{
-			// No light is being cast.
-			continue;
-		}
+		float lightMultiplier = 0.0;
 		
-		if(castsShadows)
-		{ 
+		for(uint rayIndex = 0; rayIndex < lightRayCount; ++rayIndex)
+		{
+			float3 shadowLightPosition =
+				GetValidLightLocation(
+					light, surfacePlane,
+					normalize(float3(screenUV.xy + float2(light.sceneIndex, rayIndex) + sceneConstants.noiseOffset, rayIndex + light.sceneIndex))
+					);
+
+			float maxDistance = distance(shadowLightPosition, worldPosition);
+			float3 shadowLightVector = normalize(shadowLightPosition - worldPosition);
+
 			RayQuery<RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH> inlineQuery;
 
 			// We are inside the light radius.
 			// Define a ray, consisting of origin, direction, and the min-max distance values
 			RayDesc ray;
-			ray.TMin = lerp(1.2, 0.3, max(dot(normal, lightVector), 0.0)); // To avoid precision issues, we want to start the ray a little off the surface. The more shallow the andle with the light, the further off we move.
+			ray.TMin = lerp(1.2, 0.3, max(dot(normal, shadowLightVector), 0.0)); // To avoid precision issues, we want to start the ray a little off the surface. The more shallow the andle with the light, the further off we move.
 			ray.TMax = maxDistance;
 			ray.Origin = worldPosition;// + (normal * rayStartDistance);
-			ray.Direction = lightVector;
+			ray.Direction = shadowLightVector;
 
 			if(ray.TMin < ray.TMax)
 			{ // Only trace if we have a valid distance to trace. Otherwise we can assume we are inside the light or too close to the surface.
@@ -174,14 +165,18 @@ void HandlePointLight(
 				}
 			}
 
+			lightMultiplier += 1.0;
+		}
+		
+		
+		if(lightMultiplier > 0.0)
+		{
+			lightMultiplier = lightMultiplier / lightRayCount;
 		}
 
-		diffuseResult += localDiffuse;
-		specularResult += localSpecular;
+		diffuseResult = diffuseResult * lightMultiplier;
+		specularResult = specularResult * lightMultiplier;
 	}
-
-	diffuseResult = diffuseResult / lightRayCount;
-	specularResult = specularResult / lightRayCount;
 }
 
 [shader("raygeneration")]

--- a/base/renderprogs/shadow_generator.ray
+++ b/base/renderprogs/shadow_generator.ray
@@ -135,7 +135,7 @@ void HandlePointLight(
 			pointToEye,
 			normal,
 			lightVector,
-			1.0, // Since we divide by our count later, we can just use 1.0 here. Original algorithm calls for PI
+			PI, // Since we divide by our count later, we can just use 1.0 here. Original algorithm calls for PI
 			baseReflection,
 			roughness,
 			localDiffuse,
@@ -154,36 +154,34 @@ void HandlePointLight(
 			// We are inside the light radius.
 			// Define a ray, consisting of origin, direction, and the min-max distance values
 			RayDesc ray;
-			ray.TMin = 0.0001;
-			ray.TMax = maxDistance - ray.TMin;
-			ray.Origin = worldPosition + (normal * rayStartDistance);
+			ray.TMin = lerp(1.2, 0.3, max(dot(normal, lightVector), 0.0)); // To avoid precision issues, we want to start the ray a little off the surface. The more shallow the andle with the light, the further off we move.
+			ray.TMax = maxDistance;
+			ray.Origin = worldPosition;// + (normal * rayStartDistance);
 			ray.Direction = lightVector;
 
-			if(ray.TMin >= ray.TMax)
-			{
-				// Ray is too short to trace.
-				continue;
+			if(ray.TMin < ray.TMax)
+			{ // Only trace if we have a valid distance to trace. Otherwise we can assume we are inside the light or too close to the surface.
+				inlineQuery.TraceRayInline(
+					SceneBVH,
+					RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, // OR'd with flags above
+					INSTANCE_MASK_CAST_SHADOW, // Only cast against shadow casting objects.
+					ray);
+				inlineQuery.Proceed(); // Run the tracer.
+				
+				if(inlineQuery.CommittedStatus() == COMMITTED_TRIANGLE_HIT)
+				{
+					continue; // We hit a shadow so we should not add any data to the colors
+				}
 			}
 
-			inlineQuery.TraceRayInline(
-				SceneBVH,
-				RAY_FLAG_CULL_NON_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, // OR'd with flags above
-				INSTANCE_MASK_CAST_SHADOW, // Only cast against shadow casting objects.
-				ray);
-			inlineQuery.Proceed(); // Run the tracer.
-				
-			if(inlineQuery.CommittedStatus() == COMMITTED_TRIANGLE_HIT)
-			{
-				continue; // We hit a shadow so we should not add any data to the colors
-			}
 		}
 
 		diffuseResult += localDiffuse;
 		specularResult += localSpecular;
 	}
 
-	diffuseResult = saturate(diffuseResult / lightRayCount); // TODO: Change this to a colour light space
-	specularResult = saturate(specularResult / lightRayCount);
+	diffuseResult = diffuseResult / lightRayCount;
+	specularResult = specularResult / lightRayCount;
 }
 
 [shader("raygeneration")]

--- a/neo/renderer/DX12/dx12_RenderPass.h
+++ b/neo/renderer/DX12/dx12_RenderPass.h
@@ -4,7 +4,7 @@
 #include "./dx12_global.h"
 #include "./dx12_RenderTarget.h"
 
-#define MAX_RENDER_TARGETS 5
+#define MAX_RENDER_TARGETS 6
 
 namespace DX12Rendering
 {

--- a/neo/renderer/DX12/dx12_RenderPass.h
+++ b/neo/renderer/DX12/dx12_RenderPass.h
@@ -4,7 +4,7 @@
 #include "./dx12_global.h"
 #include "./dx12_RenderTarget.h"
 
-#define MAX_RENDER_TARGETS 6
+#define MAX_RENDER_TARGETS 7
 
 namespace DX12Rendering
 {

--- a/neo/renderer/DX12/dx12_RenderProgs.cpp
+++ b/neo/renderer/DX12/dx12_RenderProgs.cpp
@@ -22,7 +22,7 @@ struct PSOKeyComparator
 {
 	bool operator()(const PSOKey& a, const PSOKey& b) const
 	{
-		return memcmp(&a, &b, sizeof(PSOKey)) < 0;
+		return memcmp(&a, &b, sizeof(PSOKey)) < 0; // This is specifically a less than comparator for the std::map
 	}
 };
 

--- a/neo/renderer/DX12/dx12_RenderTarget.cpp
+++ b/neo/renderer/DX12/dx12_RenderTarget.cpp
@@ -287,6 +287,8 @@ namespace DX12Rendering
 			m_surfaces.emplace_back(L"Position", DXGI_FORMAT_R32G32B32A32_FLOAT, eRenderSurface::Position, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"Albedo", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::Albedo, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"SpecularColor", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::SpecularColor, RENDER_SURFACE_FLAG_NONE, clearValue);
+			m_surfaces.emplace_back(L"Reflectivity", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::Reflectivity, RENDER_SURFACE_FLAG_NONE, clearValue);
+			m_surfaces.emplace_back(L"MaterialProperties", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::MaterialProperties, RENDER_SURFACE_FLAG_NONE, clearValue);
 
 			m_surfaces.emplace_back(L"RaytraceShadowMask", DXGI_FORMAT_R8G8B8A8_UINT, eRenderSurface::RaytraceShadowMask, RENDER_SURFACE_FLAG_ALLOW_UAV, clearValue);
 			m_surfaces.emplace_back(L"Global Illumination", DXGI_FORMAT_R16G16B16A16_UNORM, eRenderSurface::GlobalIllumination, RENDER_SURFACE_FLAG_ALLOW_UAV, clearValue);

--- a/neo/renderer/DX12/dx12_RenderTarget.cpp
+++ b/neo/renderer/DX12/dx12_RenderTarget.cpp
@@ -284,6 +284,7 @@ namespace DX12Rendering
 			
 			m_surfaces.emplace_back(L"Normal", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::Normal, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"FlatNormal", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::FlatNormal, RENDER_SURFACE_FLAG_NONE, clearValue);
+			m_surfaces.emplace_back(L"FlatTangent", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::FlatTangent, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"Position", DXGI_FORMAT_R32G32B32A32_FLOAT, eRenderSurface::Position, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"Albedo", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::Albedo, RENDER_SURFACE_FLAG_NONE, clearValue);
 			m_surfaces.emplace_back(L"SpecularColor", DXGI_FORMAT_R8G8B8A8_UNORM, eRenderSurface::SpecularColor, RENDER_SURFACE_FLAG_NONE, clearValue);

--- a/neo/renderer/DX12/dx12_RenderTarget.h
+++ b/neo/renderer/DX12/dx12_RenderTarget.h
@@ -29,6 +29,8 @@ namespace DX12Rendering {
 		Position, // The depth in view space
 		Albedo, // Albedo texture used for lighting
 		SpecularColor, // Specular color used for lighting.
+		Reflectivity, // The frenel reflectivity based on the normal, view angle, and material properties.
+		MaterialProperties, // R = Roughness, G = metallic, B = unused, A = unused
 
 		// RayTracing
 		RaytraceShadowMask, // Each bit is a light mask
@@ -53,6 +55,8 @@ namespace DX12Rendering {
 		eRenderSurface::Position,
 		eRenderSurface::Albedo,
 		eRenderSurface::SpecularColor,
+		eRenderSurface::Reflectivity,
+		eRenderSurface::MaterialProperties,
 
 		eRenderSurface::Diffuse,
 		eRenderSurface::Specular,

--- a/neo/renderer/DX12/dx12_RenderTarget.h
+++ b/neo/renderer/DX12/dx12_RenderTarget.h
@@ -26,6 +26,7 @@ namespace DX12Rendering {
 		// GBuffer
 		Normal, // Normals in the world space. This can be used for Raytracing.
 		FlatNormal, // Normals before normal mapping is applied.
+		FlatTangent, // Tangent of the flat surface
 		Position, // The depth in view space
 		Albedo, // Albedo texture used for lighting
 		SpecularColor, // Specular color used for lighting.
@@ -52,6 +53,7 @@ namespace DX12Rendering {
 	{
 		eRenderSurface::Normal,
 		eRenderSurface::FlatNormal,
+		eRenderSurface::FlatTangent,
 		eRenderSurface::Position,
 		eRenderSurface::Albedo,
 		eRenderSurface::SpecularColor,

--- a/neo/renderer/DX12/dx12_TextureManager.cpp
+++ b/neo/renderer/DX12/dx12_TextureManager.cpp
@@ -128,6 +128,11 @@ namespace DX12Rendering
 			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 			break;
 
+		case eGlobalTexture::WORLD_FLAT_TANGENT:
+			name = "world_flat_tangent";
+			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			break;
+
 		case eGlobalTexture::RAYTRACED_SHADOWMAP:
 			name = "raytraced_shadowmap";
 			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UINT;

--- a/neo/renderer/DX12/dx12_TextureManager.cpp
+++ b/neo/renderer/DX12/dx12_TextureManager.cpp
@@ -103,6 +103,11 @@ namespace DX12Rendering
 			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 			break;
 
+		case eGlobalTexture::MATERIAL_PROPERTIES:
+			name = "material_properties";
+			textureDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+			break;
+
 		case eGlobalTexture::RAYTRACED_DIFFUSE:
 			name = "raytraced_diffuse";
 			textureDesc.Format = DXGI_FORMAT_R16G16B16A16_UNORM;

--- a/neo/renderer/DX12/dx12_TextureManager.h
+++ b/neo/renderer/DX12/dx12_TextureManager.h
@@ -16,6 +16,7 @@ namespace DX12Rendering
 		MATERIAL_PROPERTIES, // r = Roughness, g = Metallic, b = occlusion? (not implemented)
 		WORLD_NORMALS,
 		WORLD_FLAT_NORMALS,
+		WORLD_FLAT_TANGENT,
 		RAYTRACED_SHADOWMAP,
 
 		RAYTRACED_DIFFUSE,

--- a/neo/renderer/DX12/dx12_TextureManager.h
+++ b/neo/renderer/DX12/dx12_TextureManager.h
@@ -7,6 +7,8 @@
 
 namespace DX12Rendering
 {
+	typedef GUID SamplerKey;
+
 	enum eGlobalTexture
 	{
 		DEPTH_TEXTURE,
@@ -132,6 +134,7 @@ namespace DX12Rendering
 		const D3D12_DESCRIPTOR_RANGE1* GetDescriptorRanges() { return m_descriptorRanges; }
 
 		const bool IsInitialized() { return m_isInitialized; }
+
 	private:
 		ScratchBuffer m_textureUploadHeap;
 
@@ -141,6 +144,7 @@ namespace DX12Rendering
 
 		std::vector<DX12Rendering::TextureBuffer*> m_textures; // Stores the active texture information in the scene.
 		DX12Rendering::BindlessSamplerIndex m_samplers[BINDLESS_TEXTURE_COUNT]; // Stores the active sampler index for each texture. The texture vertex must match the index of each entry.
+		SamplerKey m_samplerHash[BINDLESS_TEXTURE_COUNT];
 
 		UINT m_nextSamplerLocation;
 
@@ -149,6 +153,15 @@ namespace DX12Rendering
 		void SetTextureToDefault(UINT textureIndex);
 
 		TextureBuffer* GetTextureBuffer(const UINT index) { return m_textures[index]; }
+
+		const SamplerKey GetSamplerKey(D3D12_SAMPLER_DESC& samplerDesc) noexcept
+		{
+			SamplerKey result{};
+
+			MurmurHash3_x64_128(&samplerDesc, sizeof(D3D12_SAMPLER_DESC), 111, &result);
+
+			return result;
+		}
 	};
 
 	TextureManager* GetTextureManager();

--- a/neo/renderer/DX12/dx12_TextureManager.h
+++ b/neo/renderer/DX12/dx12_TextureManager.h
@@ -13,6 +13,7 @@ namespace DX12Rendering
 		POSITION,
 		ALBEDO,
 		SPECULAR_COLOR,
+		MATERIAL_PROPERTIES, // r = Roughness, g = Metallic, b = occlusion? (not implemented)
 		WORLD_NORMALS,
 		WORLD_FLAT_NORMALS,
 		RAYTRACED_SHADOWMAP,

--- a/neo/renderer/DX12/dx12_backend.cpp
+++ b/neo/renderer/DX12/dx12_backend.cpp
@@ -66,9 +66,10 @@ UINT GetVertexBufferSize(const vertCacheHandle_t vbHandle)
 	return (vbHandle >> VERTCACHE_SIZE_SHIFT) & VERTCACHE_SIZE_MASK;
 }
 
-void ExtractMaterialProperties(const idMaterial* material, float& roughness, float& metalic)
+void ExtractMaterialProperties(const idMaterial* material, float& roughness, float& metalic, float& specularMultiplier /* Used to modify the specular map to reflectance */)
 {
 	metalic = 0.0f;
+	specularMultiplier = 0.4f;
 
 	if (material == nullptr)
 	{
@@ -3270,7 +3271,7 @@ public:
 
 			const idMaterial* surfaceShader = surf->material;
 			idVec4 materialProps(0, 0, 0, 0);
-			ExtractMaterialProperties(surfaceShader, materialProps.x, materialProps.y);
+			ExtractMaterialProperties(surfaceShader, materialProps.x, materialProps.y, materialProps.z);
 			SetVertexParm(RENDERPARAM_MATERIAL_PROPERTIES, materialProps.ToFloatPtr());
 
 			if (surfaceShader->GetFastPathBumpImage() && !r_skipInteractionFastPath.GetBool()) {

--- a/neo/renderer/DX12/dx12_backend.cpp
+++ b/neo/renderer/DX12/dx12_backend.cpp
@@ -3073,13 +3073,14 @@ public:
 
 	virtual DX12Rendering::Commands::FenceValue Execute(const viewDef_t* viewDef, const bool raytracedEnabled) override
 	{
-		constexpr UINT surfaceCount = 5;
+		constexpr UINT surfaceCount = 6;
 		const DX12Rendering::eRenderSurface surfaces[surfaceCount] = {
 			DX12Rendering::eRenderSurface::FlatNormal,
 			DX12Rendering::eRenderSurface::Position,
 			DX12Rendering::eRenderSurface::Normal,
 			DX12Rendering::eRenderSurface::Albedo,
-			DX12Rendering::eRenderSurface::SpecularColor
+			DX12Rendering::eRenderSurface::SpecularColor,
+			DX12Rendering::eRenderSurface::MaterialProperties,
 		};
 
 		DX12Rendering::RenderPassBlock renderPassBlock("RB_DrawGBuffer", DX12Rendering::Commands::DIRECT, surfaces, surfaceCount);
@@ -3369,7 +3370,9 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 			DX12Rendering::eRenderSurface::Diffuse,
 			DX12Rendering::eRenderSurface::Specular,
 			DX12Rendering::eRenderSurface::Albedo,
-			DX12Rendering::eRenderSurface::SpecularColor
+			DX12Rendering::eRenderSurface::SpecularColor,
+			DX12Rendering::eRenderSurface::Reflectivity,
+			DX12Rendering::eRenderSurface::MaterialProperties
 		};
 
 		auto commandList = DX12Rendering::Commands::GetCommandManager(DX12Rendering::Commands::DIRECT)->RequestNewCommandList();

--- a/neo/renderer/DX12/dx12_backend.cpp
+++ b/neo/renderer/DX12/dx12_backend.cpp
@@ -1043,6 +1043,169 @@ static void RB_DrawSingleInteraction(drawInteraction_t* din) {
 	RB_DrawElementsWithCounters(din->surf);
 }
 
+void RB_DrawGBufferSurfaceWithCounters(const drawSurf_t* surf, GBufferSurfaceConstants& surfaceConstants, const bool useAmbient)
+{
+	const idMaterial* surfaceShader = surf->material;
+	idVec4 materialProps(0, 0, 0, 0);
+	ExtractMaterialProperties(surfaceShader, materialProps.x, materialProps.y, materialProps.z);
+	SetVertexParm(RENDERPARAM_MATERIAL_PROPERTIES, materialProps.ToFloatPtr());
+
+	if (surfaceShader->GetFastPathBumpImage() && !r_skipInteractionFastPath.GetBool()) {
+		// texture 0 will be the per-surface bump map
+		surfaceConstants.bumpMapIndex = LoadBindlessTexture(surfaceShader->GetFastPathBumpImage());
+
+		// texture 3 is the per-surface diffuse map
+		surfaceConstants.albedoIndex = LoadBindlessTexture(surfaceShader->GetFastPathDiffuseImage());
+
+		// texture 4 is the per-surface specular map
+		surfaceConstants.specularIndex = LoadBindlessTexture(surfaceShader->GetFastPathSpecularImage());
+
+		const idVec4 sMatrix(1, 0, 0, 0);
+		const idVec4 tMatrix(0, 1, 0, 0);
+
+		SetVertexParm(RENDERPARM_BUMPMATRIX_S, sMatrix.ToFloatPtr());
+		SetVertexParm(RENDERPARM_BUMPMATRIX_T, tMatrix.ToFloatPtr());
+
+		SetVertexParm(RENDERPARM_DIFFUSEMATRIX_S, sMatrix.ToFloatPtr());
+		SetVertexParm(RENDERPARM_DIFFUSEMATRIX_T, tMatrix.ToFloatPtr());
+
+		SetVertexParm(RENDERPARM_SPECULARMATRIX_S, sMatrix.ToFloatPtr());
+		SetVertexParm(RENDERPARM_SPECULARMATRIX_T, tMatrix.ToFloatPtr());
+	}
+	else
+	{
+		const float* surfaceRegs = surf->shaderRegisters;
+		bool bumpMapFound = false;
+		bool diffuseMapFound = false;
+		bool specularMapFound = false;
+
+		for (int surfaceStageNum = 0; surfaceStageNum < surfaceShader->GetNumStages(); surfaceStageNum++) {
+			const shaderStage_t* surfaceStage = surfaceShader->GetStage(surfaceStageNum);
+
+			switch (surfaceStage->lighting) {
+			case SL_COVERAGE: {
+				// ignore any coverage stages since they should only be used for the depth fill pass
+				// for diffuse stages that use alpha test.
+				break;
+			}
+			case SL_AMBIENT: {
+				// Ignore ambient
+				if (!useAmbient)
+				{
+					break;
+				}
+				
+				// ignore stage that fails the condition
+				if (!surfaceRegs[surfaceStage->conditionRegister]) {
+					break;
+				}
+
+				if (diffuseMapFound)
+				{
+					// Already loaded the texture, draw the surface.
+					RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+				}
+				diffuseMapFound = true;
+
+				// texture 3 will be the diffuse map
+				surfaceConstants.albedoIndex = LoadBindlessTexture(surfaceStage->texture.image);
+
+				idVec4 matrix[2];
+				RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
+					matrix, NULL);
+
+				// bump matrix
+				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_S, matrix[0].ToFloatPtr());
+				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_T, matrix[1].ToFloatPtr());
+
+				break;
+			}
+			case SL_BUMP: {
+				// ignore stage that fails the condition
+				if (!surfaceRegs[surfaceStage->conditionRegister]) {
+					break;
+				}
+
+				if (bumpMapFound)
+				{
+					// Already loaded the texture, draw the surface.
+					RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+				}
+				bumpMapFound = true;
+
+				// texture 0 will be the per-surface bump map
+				surfaceConstants.bumpMapIndex = LoadBindlessTexture(surfaceStage->texture.image);
+
+				idVec4 bumpMatrix[2];
+				RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
+					bumpMatrix, NULL);
+
+				// bump matrix
+				SetVertexParm(RENDERPARM_BUMPMATRIX_S, bumpMatrix[0].ToFloatPtr());
+				SetVertexParm(RENDERPARM_BUMPMATRIX_T, bumpMatrix[1].ToFloatPtr());
+
+				break;
+			}
+			case SL_DIFFUSE: {
+				// ignore stage that fails the condition
+				if (!surfaceRegs[surfaceStage->conditionRegister]) {
+					break;
+				}
+
+				if (diffuseMapFound)
+				{
+					// Already loaded the texture, draw the surface.
+					RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+				}
+				diffuseMapFound = true;
+
+				// texture 3 will be the diffuse map
+				surfaceConstants.albedoIndex = LoadBindlessTexture(surfaceStage->texture.image);
+
+				idVec4 matrix[2];
+				RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
+					matrix, NULL);
+
+				// bump matrix
+				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_S, matrix[0].ToFloatPtr());
+				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_T, matrix[1].ToFloatPtr());
+
+				break;
+			}
+			case SL_SPECULAR: {
+				// ignore stage that fails the condition
+				if (!surfaceRegs[surfaceStage->conditionRegister]) {
+					break;
+				}
+
+				if (specularMapFound)
+				{
+					// Already loaded the texture, draw the surface.
+					RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+				}
+				specularMapFound = true;
+
+				// texture 3 will be the diffuse map
+				surfaceConstants.specularIndex = LoadBindlessTexture(surfaceStage->texture.image);
+
+				idVec4 matrix[2];
+				RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
+					matrix, NULL);
+
+				// bump matrix
+				SetVertexParm(RENDERPARM_SPECULARMATRIX_S, matrix[0].ToFloatPtr());
+				SetVertexParm(RENDERPARM_SPECULARMATRIX_T, matrix[1].ToFloatPtr());
+
+				break;
+			}
+			}
+		}
+	}
+
+	// draw it solid
+	RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+}
+
 /*
 =============
 GL_BlockingSwapBuffers
@@ -1568,7 +1731,7 @@ RB_RenderInteractions
 With added sorting and trivial path work.
 =============
 */
-static void RB_RenderInteractions(const drawSurf_t* surfList, const viewLight_t* vLight, int depthFunc, bool performStencilTest, bool useLightDepthBounds) {
+static void RB_RenderInteractions(const drawSurf_t* surfList, const viewLight_t* vLight, int depthFunc, bool performStencilTest, bool useLightDepthBounds, const bool gBufferDecals) {
 	if (surfList == NULL) {
 		return;
 	}
@@ -1629,6 +1792,13 @@ static void RB_RenderInteractions(const drawSurf_t* surfList, const viewLight_t*
 		}
 
 		const idMaterial* surfaceShader = walk->material;
+
+		if (gBufferDecals && surfaceShader->GetSort() == SS_DECAL)
+		{
+			// Do not record decals as they've been placed on the gbuffer
+			continue;
+		}
+
 		if (surfaceShader->GetFastPathBumpImage()) {
 			allSurfaces.Append(walk);
 		}
@@ -1893,7 +2063,7 @@ DRAW INTERACTIONS
 RB_DrawInteractions
 ==================
 */
-static void RB_DrawInteractions(const bool useRaytracing) {
+static void RB_DrawInteractions(const bool useRaytracing, const bool gBufferDecals) {
 	if (r_skipInteractions.GetBool()) {
 		return;
 	}
@@ -1983,7 +2153,7 @@ static void RB_DrawInteractions(const bool useRaytracing) {
 				DX12Rendering::Commands::CommandManagerCycleBlock childBlock(renderPassBlock.GetCommandManager(), "Local Light Interactions");
 
 				renderLog.OpenBlock("Local Light Interactions");
-				RB_RenderInteractions(vLight->localInteractions, vLight, GLS_DEPTHFUNC_EQUAL, performStencilTest, useLightDepthBounds);
+				RB_RenderInteractions(vLight->localInteractions, vLight, GLS_DEPTHFUNC_EQUAL, performStencilTest, useLightDepthBounds, gBufferDecals);
 				renderLog.CloseBlock();
 			}
 
@@ -1999,7 +2169,7 @@ static void RB_DrawInteractions(const bool useRaytracing) {
 				DX12Rendering::Commands::CommandManagerCycleBlock childBlock(renderPassBlock.GetCommandManager(), "Global Light Interactions");
 
 				renderLog.OpenBlock("Global Light Interactions");
-				RB_RenderInteractions(vLight->globalInteractions, vLight, GLS_DEPTHFUNC_EQUAL, performStencilTest, useLightDepthBounds);
+				RB_RenderInteractions(vLight->globalInteractions, vLight, GLS_DEPTHFUNC_EQUAL, performStencilTest, useLightDepthBounds, gBufferDecals);
 				renderLog.CloseBlock();
 			}
 		}
@@ -2024,7 +2194,7 @@ static void RB_DrawInteractions(const bool useRaytracing) {
 			// stencil shadows only affect surfaces that contribute to the view depth
 			// buffer and translucent surfaces do not contribute to the view depth buffer.
 
-			RB_RenderInteractions(vLight->translucentInteractions, vLight, GLS_DEPTHFUNC_LESS, false, false);
+			RB_RenderInteractions(vLight->translucentInteractions, vLight, GLS_DEPTHFUNC_LESS, false, false, gBufferDecals);
 
 			renderLog.CloseBlock();
 		}
@@ -2072,7 +2242,7 @@ be multiplied by guiEye for polarity and screenSeparation for scale.
 =====================
 */
 static int RB_DrawShaderPasses(const drawSurf_t* const* const drawSurfs, const int numDrawSurfs,
-	const float guiStereoScreenOffset, const int stereoEye) {
+	const float guiStereoScreenOffset, const int stereoEye, const bool gBufferDecals) {
 	// only obey skipAmbient if we are rendering a view
 	if (backEnd.viewDef->viewEntitys && r_skipAmbient.GetBool()) {
 		return numDrawSurfs;
@@ -2092,6 +2262,12 @@ static int RB_DrawShaderPasses(const drawSurf_t* const* const drawSurfs, const i
 	for (; i < numDrawSurfs; i++) {
 		const drawSurf_t* surf = drawSurfs[i];
 		const idMaterial* shader = surf->material;
+
+		if (gBufferDecals && shader->GetSort() == SS_DECAL)
+		{
+			// We are putting the decals into hte GBuffer and do not need to draw them here.
+			continue;
+		}
 
 		if (!shader->HasAmbient()) {
 			continue;
@@ -3120,7 +3296,48 @@ public:
 
 	virtual DX12Rendering::Commands::FenceValue Execute(const viewDef_t* viewDef, const bool raytracedEnabled) override
 	{
-		// TODO: Finish this up
+		if (r_skipInteractions.GetBool() || !r_skipTranslucent.GetBool()) 
+		{
+			return DX12Rendering::Commands::FenceValue::Empty(DX12Rendering::Commands::DIRECT);
+		}
+
+		DX12Rendering::RenderPassBlock renderPassBlock("DrawTransparents", DX12Rendering::Commands::DIRECT);
+		DX12Rendering::TextureManager* textureManager = DX12Rendering::GetTextureManager();
+
+		const bool useLightDepthBounds = r_useLightDepthBounds.GetBool();
+
+		for (const viewLight_t* vLight = backEnd.viewDef->viewLights; vLight != NULL; vLight = vLight->next) {
+			// do fogging later
+			if (vLight->lightShader->IsFogLight()) {
+				continue;
+			}
+
+			if (vLight->lightShader->IsBlendLight()) {
+				continue;
+			}
+
+			if (vLight->translucentInteractions == NULL) {
+				continue;
+			}
+
+			const idMaterial* lightShader = vLight->lightShader;
+			renderLog.OpenBlock(lightShader->GetName());
+
+			// Disable the depth bounds test because translucent surfaces don't work with
+			// the depth bounds tests since they did not write depth during the depth pass.
+			if (useLightDepthBounds) {
+				GL_DepthBoundsTest(0.0f, 0.0f);
+			}
+
+			//Mark start here , do the draw interactions here
+
+			renderLog.CloseBlock();
+		}
+
+		DX12Rendering::Commands::CommandManager* commandManager = renderPassBlock.GetCommandManager();
+		const DX12Rendering::Commands::FenceValue fence = commandManager->InsertFenceSignal();
+
+		return fence;
 	}
 
 private:
@@ -3132,7 +3349,8 @@ private:
 class GBufferDecalPass : public RenderPass
 {
 public:
-	GBufferDecalPass(const int size)
+	GBufferDecalPass(const int size, const float guiStereoScreenOffset) :
+		m_guiStereoScreenOffset(guiStereoScreenOffset)
 	{
 		m_surfaces.reserve(size);
 	}
@@ -3140,15 +3358,280 @@ public:
 	// Inherited via RenderPass
 	virtual void Gather(const drawSurf_t* ds, const int index) override
 	{
-		// TODO: Gather all the decals.
+		const idMaterial* shader = ds->material;
+
+		if (shader->GetSort() != SS_DECAL)
+		{
+			return;
+		}
+
+		if (ds->space->isGuiSurface)
+		{
+			return;
+		}
+
+		if (shader->IsPortalSky()) {
+			return;
+		}
+
+		// some deforms may disable themselves by setting numIndexes = 0
+		if (ds->numIndexes == 0) {
+			return;
+		}
+
+		if (shader->SuppressInSubview()) {
+			return;
+		}
+
+		if (ds->space->isGuiSurface)
+		{
+			return;
+		}
+
 		// We want to then also add and Emissive buffer to the GBuffer pass, this will allow us to build our emissives early
+
+		m_surfaces.push_back(ds);
 	}
 
 	virtual DX12Rendering::Commands::FenceValue Execute(const viewDef_t* viewDef, const bool raytracedEnabled) override
 	{
+		// TODO: Mark start here and fix no ambient textures.
+		constexpr UINT surfaceCount = 1;
+		const DX12Rendering::eRenderSurface surfaces[surfaceCount] = {
+			DX12Rendering::eRenderSurface::Albedo,
+		};
+
+		GL_SelectTexture(1);
+		globalImages->BindNull();
+
+		GL_SelectTexture(0);
+
+		DX12Rendering::RenderPassBlock renderPassBlock("RB_DrawGBufferDecals", DX12Rendering::Commands::DIRECT, surfaces, surfaceCount);
+
+		//First fill in the sub view surfaces
+		std::vector<const drawSurf_t*>::iterator it = m_surfaces.begin();
+
+		float currentGuiStereoOffset = 0.0f;
+
+		// continue checking past the subview surfaces
+		while (it != m_surfaces.end())
+		{
+			GBufferSurfaceConstants surfaceConstants = {};
+			const drawSurf_t* surf = *it;
+			const idMaterial* shader = surf->material;
+			++it; // Prepare the next itteration
+
+			if (viewDef->isXraySubview && surf->space->entityDef) {
+				if (surf->space->entityDef->parms.xrayIndex != 2) {
+					continue;
+				}
+			}
+
+			// determine the stereoDepth offset 
+			// guiStereoScreenOffset will always be zero for 3D views, so the !=
+			// check will never force an update due to the current sort value.
+			const float thisGuiStereoOffset = m_guiStereoScreenOffset * surf->sort;
+
+			GL_State(GLS_DEPTHMASK | GLS_DEPTHFUNC_EQUAL | GLS_STENCIL_FUNC_ALWAYS);
+
+			renderProgManager.BindShader_Texture();
+
+			// set mvp matrix
+			if (surf->space != backEnd.currentSpace) {
+				RB_SetMVP(surf->space->mvp);
+				backEnd.currentSpace = surf->space;
+
+				// set the Normal Matrix (technically it's the transpose of the model matrix)
+				const float* modelMatrix = surf->space->modelMatrix;
+				idMat4 normalMatrix(
+					modelMatrix[0], modelMatrix[1], modelMatrix[2], modelMatrix[3],
+					modelMatrix[4], modelMatrix[5], modelMatrix[6], modelMatrix[7],
+					modelMatrix[8], modelMatrix[9], modelMatrix[10], modelMatrix[11],
+					modelMatrix[12], modelMatrix[13], modelMatrix[14], modelMatrix[15]
+				); // TODO: Precalculate value
+				//normalMatrix = normalMatrix.Transpose();
+				normalMatrix = normalMatrix.Inverse();
+				float normalMatrixTranspose[16];
+				R_MatrixTranspose(normalMatrix.ToFloatPtr(), normalMatrixTranspose);
+				//TODO: Find the appropriate matrix
+				SetVertexParms(RENDERPARM_NORMALMATRIX_X, normalMatrix.ToFloatPtr(), 4);
+
+				// set model Matrix
+				float modelMatrixTranspose[16];
+				R_MatrixTranspose(surf->space->modelMatrix, modelMatrixTranspose);
+				SetVertexParms(RENDERPARM_MODELMATRIX_X, modelMatrixTranspose, 4);
+
+				// Set ModelView Matrix
+				float modelViewMatrixTranspose[16];
+				R_MatrixTranspose(surf->space->modelViewMatrix, modelViewMatrixTranspose);
+				SetVertexParms(RENDERPARM_MODELVIEWMATRIX_X, modelViewMatrixTranspose, 4);
+			}
+
+			const idMaterial* surfaceShader = surf->material;
+			const float* surfaceRegs = surf->shaderRegisters;
+
+			GL_Cull(shader->GetCullType());
+			uint64 surfGLState = surf->extraGLState;
+
+			// set polygon offset if necessary
+			if (shader->TestMaterialFlag(MF_POLYGONOFFSET)) {
+				GL_PolygonOffset(r_offsetFactor.GetFloat(), r_offsetUnits.GetFloat() * shader->GetPolygonOffset());
+				surfGLState = GLS_POLYGON_OFFSET;
+			}
+
+			for (int stage = 0; stage < shader->GetNumStages(); stage++)
+			{
+				const shaderStage_t* pStage = shader->GetStage(stage);
+
+				// check the enable condition
+				if (surfaceRegs[pStage->conditionRegister] == 0) {
+					continue;
+				}
+
+				uint64 stageGLState = surfGLState;
+				if ((surfGLState & GLS_OVERRIDE) == 0) {
+					stageGLState |= pStage->drawStateBits;
+				}
+
+				// skip if the stage is ( GL_ZERO, GL_ONE ), which is used for some alpha masks
+				if ((stageGLState & (GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS)) == (GLS_SRCBLEND_ZERO | GLS_DSTBLEND_ONE)) {
+					continue;
+				}
+
+				// TODO: Add section here to detect fully bright.
+
+				// see if we are a new-style stage
+				newShaderStage_t* newStage = pStage->newStage;
+				if (newStage != NULL)
+				{
+					renderLog.OpenBlock("New Shader Stage");
+
+					GL_State(stageGLState);
+
+					renderProgManager.BindShader(newStage->glslProgram, newStage->glslProgram);
+
+					for (int j = 0; j < newStage->numVertexParms; j++) {
+						float parm[4];
+						parm[0] = surfaceRegs[newStage->vertexParms[j][0]];
+						parm[1] = surfaceRegs[newStage->vertexParms[j][1]];
+						parm[2] = surfaceRegs[newStage->vertexParms[j][2]];
+						parm[3] = surfaceRegs[newStage->vertexParms[j][3]];
+						SetVertexParm((renderParm_t)(RENDERPARM_USER + j), parm);
+					}
+
+					// set rpEnableSkinning if the shader has optional support for skinning
+					if (surf->jointCache && renderProgManager.ShaderHasOptionalSkinning()) {
+						const idVec4 skinningParm(1.0f);
+						SetVertexParm(RENDERPARM_ENABLE_SKINNING, skinningParm.ToFloatPtr());
+					}
+
+					// bind texture units
+					for (int j = 0; j < newStage->numFragmentProgramImages; j++) {
+						idImage* image = newStage->fragmentProgramImages[j];
+						if (image != NULL) {
+							GL_SelectTexture(j);
+							image->Bind();
+						}
+					}
+
+					// draw it
+					RB_DrawElementsWithCounters(surf);
+
+					// unbind texture units
+					for (int j = 0; j < newStage->numFragmentProgramImages; j++) {
+						idImage* image = newStage->fragmentProgramImages[j];
+						if (image != NULL) {
+							GL_SelectTexture(j);
+							globalImages->BindNull();
+						}
+					}
+
+					// clear rpEnableSkinning if it was set
+					if (surf->jointCache && renderProgManager.ShaderHasOptionalSkinning()) {
+						const idVec4 skinningParm(0.0f);
+						SetVertexParm(RENDERPARM_ENABLE_SKINNING, skinningParm.ToFloatPtr());
+					}
+
+					GL_SelectTexture(0);
+					renderProgManager.Unbind();
+
+					renderLog.CloseBlock();
+					continue;
+				}
+
+				// Old Style stages
+				// set the color
+				float color[4];
+				color[0] = surfaceRegs[pStage->color.registers[0]];
+				color[1] = surfaceRegs[pStage->color.registers[1]];
+				color[2] = surfaceRegs[pStage->color.registers[2]];
+				color[3] = surfaceRegs[pStage->color.registers[3]];
+
+				// skip the entire stage if an add would be black
+				if ((stageGLState & (GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS)) == (GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE) //TODO: Move this to the top as it seems to affect both new and old stages.
+					&& color[0] <= 0 && color[1] <= 0 && color[2] <= 0) {
+					continue;
+				}
+
+				// skip the entire stage if a blend would be completely transparent
+				if ((stageGLState & (GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS)) == (GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA)
+					&& color[3] <= 0) {
+					continue;
+				}
+
+				stageVertexColor_t svc = pStage->vertexColor;
+
+
+				renderLog.OpenBlock("Old Shader Stage");
+				GL_Color(color);
+
+
+				// We only use Decals so we don't need to check for these other sections.
+				if (surf->jointCache) {
+					renderProgManager.BindShader_TextureVertexColorSkinned();
+				}
+				else {
+					renderProgManager.BindShader_TextureVertexColor();
+				}
+
+				RB_SetVertexColorParms(svc);
+
+				// bind the texture
+				RB_BindVariableStageImage(&pStage->texture, surfaceRegs);
+
+				// set privatePolygonOffset if necessary
+				if (pStage->privatePolygonOffset) {
+					GL_PolygonOffset(r_offsetFactor.GetFloat(), r_offsetUnits.GetFloat() * pStage->privatePolygonOffset);
+					stageGLState |= GLS_POLYGON_OFFSET;
+				}
+
+				// set the state
+				GL_State(stageGLState);
+
+				RB_PrepareStageTexturing(pStage, surf);
+
+				// draw it
+				RB_DrawElementsWithCounters(surf);
+
+				// unset privatePolygonOffset if necessary
+				if (pStage->privatePolygonOffset) {
+					GL_PolygonOffset(r_offsetFactor.GetFloat(), r_offsetUnits.GetFloat() * shader->GetPolygonOffset());
+				}
+				renderLog.CloseBlock();
+			}
+
+			GL_Cull(CT_FRONT_SIDED);
+			GL_Color(1.0f, 1.0f, 1.0f);
+		}
+
+		DX12Rendering::Commands::CommandManager* commandManager = renderPassBlock.GetCommandManager();
+		const DX12Rendering::Commands::FenceValue fence = commandManager->InsertFenceSignal();
+
+		return fence;
 	}
 
 private:
+	const float m_guiStereoScreenOffset;
 	std::vector<const drawSurf_t*> m_surfaces;
 };
 
@@ -3187,9 +3670,10 @@ public:
 
 	virtual DX12Rendering::Commands::FenceValue Execute(const viewDef_t* viewDef, const bool raytracedEnabled) override
 	{
-		constexpr UINT surfaceCount = 6;
+		constexpr UINT surfaceCount = 7;
 		const DX12Rendering::eRenderSurface surfaces[surfaceCount] = {
 			DX12Rendering::eRenderSurface::FlatNormal,
+			DX12Rendering::eRenderSurface::FlatTangent,
 			DX12Rendering::eRenderSurface::Position,
 			DX12Rendering::eRenderSurface::Normal,
 			DX12Rendering::eRenderSurface::Albedo,
@@ -3214,14 +3698,13 @@ public:
 		}
 
 		//TODO: Clear the buffers
-		//TODO: Implement perforated serfaces
+		//TODO: Implement perforated surfaces
 		//TODO: Move to it's own buffer to render and cast rays'
-
-		GBufferSurfaceConstants surfaceConstants = {};
 
 		// continue checking past the subview surfaces
 		while (it != m_surfaces.end()) 
 		{
+			GBufferSurfaceConstants surfaceConstants = {};
 			const drawSurf_t* surf = *it;
 			const idMaterial* shader = surf->material;
 			++it; // Prepare the next itteration
@@ -3269,137 +3752,7 @@ public:
 				SetVertexParms(RENDERPARM_MODELVIEWMATRIX_X, modelViewMatrixTranspose, 4);
 			}
 
-			const idMaterial* surfaceShader = surf->material;
-			idVec4 materialProps(0, 0, 0, 0);
-			ExtractMaterialProperties(surfaceShader, materialProps.x, materialProps.y, materialProps.z);
-			SetVertexParm(RENDERPARAM_MATERIAL_PROPERTIES, materialProps.ToFloatPtr());
-
-			if (surfaceShader->GetFastPathBumpImage() && !r_skipInteractionFastPath.GetBool()) {
-				// texture 0 will be the per-surface bump map
-				surfaceConstants.bumpMapIndex = LoadBindlessTexture(surfaceShader->GetFastPathBumpImage());
-
-				// texture 3 is the per-surface diffuse map
-				surfaceConstants.albedoIndex = LoadBindlessTexture(surfaceShader->GetFastPathDiffuseImage());
-
-				// texture 4 is the per-surface specular map
-				surfaceConstants.specularIndex = LoadBindlessTexture(surfaceShader->GetFastPathSpecularImage());
-
-				const idVec4 sMatrix(1, 0, 0, 0);
-				const idVec4 tMatrix(0, 1, 0, 0);
-
-				SetVertexParm(RENDERPARM_BUMPMATRIX_S, sMatrix.ToFloatPtr());
-				SetVertexParm(RENDERPARM_BUMPMATRIX_T, tMatrix.ToFloatPtr());
-
-				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_S, sMatrix.ToFloatPtr());
-				SetVertexParm(RENDERPARM_DIFFUSEMATRIX_T, tMatrix.ToFloatPtr());
-
-				SetVertexParm(RENDERPARM_SPECULARMATRIX_S, sMatrix.ToFloatPtr());
-				SetVertexParm(RENDERPARM_SPECULARMATRIX_T, tMatrix.ToFloatPtr());
-			}
-			else
-			{
-				const float* surfaceRegs = surf->shaderRegisters;
-				bool bumpMapFound = false;
-				bool diffuseMapFound = false;
-				bool specularMapFound = false;
-
-				for (int surfaceStageNum = 0; surfaceStageNum < surfaceShader->GetNumStages(); surfaceStageNum++) {
-					const shaderStage_t* surfaceStage = surfaceShader->GetStage(surfaceStageNum);
-
-					switch (surfaceStage->lighting) {
-					case SL_COVERAGE: {
-						// ignore any coverage stages since they should only be used for the depth fill pass
-						// for diffuse stages that use alpha test.
-						break;
-					}
-					case SL_AMBIENT: {
-						// ignore ambient stages while drawing interactions
-						break;
-					}
-					case SL_BUMP: {
-						// ignore stage that fails the condition
-						if (!surfaceRegs[surfaceStage->conditionRegister]) {
-							break;
-						}
-
-						if (bumpMapFound)
-						{
-							// Already loaded the texture, draw the surface.
-							RB_DrawElementsWithCounters(surf);
-						}
-						bumpMapFound = true;
-
-						// texture 0 will be the per-surface bump map
-						surfaceConstants.bumpMapIndex = LoadBindlessTexture(surfaceStage->texture.image);
-
-						idVec4 bumpMatrix[2];
-						RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
-							bumpMatrix, NULL);
-
-						// bump matrix
-						SetVertexParm(RENDERPARM_BUMPMATRIX_S, bumpMatrix[0].ToFloatPtr());
-						SetVertexParm(RENDERPARM_BUMPMATRIX_T, bumpMatrix[1].ToFloatPtr());
-
-						break;
-					}
-					case SL_DIFFUSE: {
-						// ignore stage that fails the condition
-						if (!surfaceRegs[surfaceStage->conditionRegister]) {
-							break;
-						}
-
-						if (diffuseMapFound)
-						{
-							// Already loaded the texture, draw the surface.
-							RB_DrawElementsWithCounters(surf);
-						}
-						diffuseMapFound = true;
-
-						// texture 3 will be the diffuse map
-						surfaceConstants.albedoIndex = LoadBindlessTexture(surfaceStage->texture.image);
-
-						idVec4 matrix[2];
-						RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
-							matrix, NULL);
-
-						// bump matrix
-						SetVertexParm(RENDERPARM_DIFFUSEMATRIX_S, matrix[0].ToFloatPtr());
-						SetVertexParm(RENDERPARM_DIFFUSEMATRIX_T, matrix[1].ToFloatPtr());
-
-						break;
-					}
-					case SL_SPECULAR: {
-						// ignore stage that fails the condition
-						if (!surfaceRegs[surfaceStage->conditionRegister]) {
-							break;
-						}
-
-						if (specularMapFound)
-						{
-							// Already loaded the texture, draw the surface.
-							RB_DrawElementsWithCounters(surf);
-						}
-						specularMapFound = true;
-
-						// texture 3 will be the diffuse map
-						surfaceConstants.specularIndex = LoadBindlessTexture(surfaceStage->texture.image);
-
-						idVec4 matrix[2];
-						RB_SetupInteractionStage(surfaceStage, surfaceRegs, NULL,
-							matrix, NULL);
-
-						// bump matrix
-						SetVertexParm(RENDERPARM_SPECULARMATRIX_S, matrix[0].ToFloatPtr());
-						SetVertexParm(RENDERPARM_SPECULARMATRIX_T, matrix[1].ToFloatPtr());
-
-						break;
-					}
-					}
-				}
-			}
-
-			// draw it solid
-			RB_DrawElementsWithCounters(surf, &surfaceConstants, sizeof(GBufferSurfaceConstants));
+			RB_DrawGBufferSurfaceWithCounters(surf, surfaceConstants, false);
 		}
 
 		DX12Rendering::Commands::CommandManager* commandManager = renderPassBlock.GetCommandManager();
@@ -3433,21 +3786,33 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 	const int numDrawSurfs = viewDef->numDrawSurfs;
 
 	const bool raytracedEnabled = dxRenderer.IsRaytracingEnabled() && (backEnd.viewDef->viewEntitys != NULL /* Only can be used on 3d models */);
+	const bool gBufferDecals = false && raytracedEnabled;
 	const bool useGBuffer = raytracedEnabled;
 
 	std::vector<const drawSurf_t*> dynamicSurfaces;
 	dynamicSurfaces.reserve(numDrawSurfs);
 
+	float guiScreenOffset;
+	if (!gBufferDecals || viewDef->viewEntitys != NULL) {
+		// guiScreenOffset will be 0 in non-gui views
+		guiScreenOffset = 0.0f;
+	}
+	else {
+		guiScreenOffset = stereoEye * viewDef->renderView.stereoScreenSeparation;
+	}
+
 	EvaluateMaterialPass evaluateMaterialPass;
 	DynamicSurfacesPass dynamicSurfacesPass(numDrawSurfs);
 	FillDepthBufferFastPass fillDepthBufferPass(numDrawSurfs);
 	GBufferPass gBufferPass(numDrawSurfs);
+	GBufferDecalPass gBufferDecalPass(numDrawSurfs, guiScreenOffset);
 
 	RenderPass* renderPasses[] = {
 		&evaluateMaterialPass,
 		&dynamicSurfacesPass,
 		&fillDepthBufferPass,
-		&gBufferPass
+		&gBufferPass,
+		&gBufferDecalPass
 	};
 
 	GatherSurfacesPerStage(viewDef, renderPasses, std::size(renderPasses));
@@ -3491,6 +3856,7 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 			DX12Rendering::eRenderSurface::Position,
 			DX12Rendering::eRenderSurface::Normal,
 			DX12Rendering::eRenderSurface::FlatNormal,
+			DX12Rendering::eRenderSurface::FlatTangent,
 			DX12Rendering::eRenderSurface::RaytraceShadowMask,
 			DX12Rendering::eRenderSurface::GlobalIllumination,
 			DX12Rendering::eRenderSurface::Diffuse,
@@ -3648,7 +4014,8 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 		if (useGBuffer)
 		{
 			// Fill the GBuffer
-			const DX12Rendering::Commands::FenceValue fence = gBufferPass.Execute(viewDef, raytracedEnabled);
+			const DX12Rendering::Commands::FenceValue fenceGBuffer = gBufferPass.Execute(viewDef, raytracedEnabled);
+			const DX12Rendering::Commands::FenceValue fence = gBufferDecals ? gBufferDecalPass.Execute(viewDef, raytracedEnabled) : fenceGBuffer;
 
 			DX12Rendering::Commands::GetCommandManager(DX12Rendering::Commands::COPY)->InsertFenceWait(fence);
 
@@ -3681,6 +4048,11 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 			DX12Rendering::TextureBuffer* normalFlatTexture = textureManager->GetGlobalTexture(DX12Rendering::eGlobalTexture::WORLD_FLAT_NORMALS);
 			normalFlatMap->CopySurfaceToTexture(normalFlatTexture, textureManager);
 
+			// Copy the flat normal map to a texture
+			auto tangentFlatMap = DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::FlatTangent);
+			DX12Rendering::TextureBuffer* tangentFlatTexture = textureManager->GetGlobalTexture(DX12Rendering::eGlobalTexture::WORLD_FLAT_TANGENT);
+			tangentFlatMap->CopySurfaceToTexture(tangentFlatTexture, textureManager);
+
 			// Copy the normal map to a texture
 			auto normalMap = DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::Normal);
 			DX12Rendering::TextureBuffer* normalTexture = textureManager->GetGlobalTexture(DX12Rendering::eGlobalTexture::WORLD_NORMALS);
@@ -3710,7 +4082,7 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 	//-------------------------------------------------
 	// main light renderer
 	//-------------------------------------------------
-	RB_DrawInteractions(raytracedEnabled);
+	RB_DrawInteractions(raytracedEnabled, gBufferDecals);
 	//dxRenderer.ExecuteCommandList();
 	//dxRenderer.ResetCommandList();
 
@@ -3730,7 +4102,7 @@ void RB_DrawViewInternal(const viewDef_t* viewDef, const int stereoEye) {
 		else {
 			guiScreenOffset = stereoEye * viewDef->renderView.stereoScreenSeparation;
 		}
-		processed = RB_DrawShaderPasses(drawSurfs, numDrawSurfs, guiScreenOffset, stereoEye);
+		processed = RB_DrawShaderPasses(drawSurfs, numDrawSurfs, guiScreenOffset, stereoEye, gBufferDecals);
 		renderLog.CloseMainBlock();
 	}
 

--- a/neo/renderer/DX12/dx12_raytracing.cpp
+++ b/neo/renderer/DX12/dx12_raytracing.cpp
@@ -86,6 +86,7 @@ namespace DX12Rendering {
 			m_constantBuffer.normalIndex = textureManager->GetGlobalTexture(eGlobalTexture::WORLD_NORMALS)->GetTextureIndex();
 			m_constantBuffer.diffuseTextureIndex = textureManager->GetGlobalTexture(eGlobalTexture::ALBEDO)->GetTextureIndex();
 			m_constantBuffer.specularTextureIndex = textureManager->GetGlobalTexture(eGlobalTexture::SPECULAR_COLOR)->GetTextureIndex();
+			m_constantBuffer.materialTextureIndex = textureManager->GetGlobalTexture(eGlobalTexture::MATERIAL_PROPERTIES)->GetTextureIndex();
 
 			m_constantBuffer.raysPerLight = s_raysCastPerLight.GetInteger();
 

--- a/neo/renderer/DX12/dx12_raytracing.cpp
+++ b/neo/renderer/DX12/dx12_raytracing.cpp
@@ -11,7 +11,7 @@
 
 idCVar s_raysCastPerLight("s_raysCastPerLight", "20", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "number of shadow rays per light per pixel.", 0, 1000);
 idCVar s_lightEmissiveRadius("s_lightEmissiveRadius", "20.0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_FLOAT, "the radius of a light. The larger the value, the softer shadows will be.", 0.0f, 100.0f);
-idCVar r_useGli("r_useGli", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "use raytraced global illumination.");
+idCVar r_useGli("r_useGli", "0", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_BOOL, "use raytraced global illumination.");
 idCVar r_gliResolution("r_gliResolution", "0.33" /*"0.125"*/, CVAR_RENDERER | CVAR_FLOAT, "the percentage of global illumination points to cast per screen axis.", 0.0f, 1.0f);
 idCVar r_gliBounces("r_gliBounces", "1", CVAR_RENDERER | CVAR_ARCHIVE | CVAR_INTEGER, "the max number of global illumination bounces allowed.", 0, 10);
 

--- a/neo/renderer/DX12/dx12_raytracing.cpp
+++ b/neo/renderer/DX12/dx12_raytracing.cpp
@@ -336,7 +336,12 @@ namespace DX12Rendering {
 
 		m_lights[index].scissor = scissorWindow;
 
-		m_lights[index].color = color;
+		m_lights[index].diffuseColor = color;
+
+		m_lights[index].specularColor.x = color.x * 2.0f;
+		m_lights[index].specularColor.y = color.y * 2.0f;
+		m_lights[index].specularColor.z = color.z * 2.0f;
+		m_lights[index].specularColor.w = color.w * 2.0f;
 
 		memcpy(&m_lights[index].projectionS, &lightProjection[0], sizeof(float) * 4);
 		memcpy(&m_lights[index].projectionT, &lightProjection[1], sizeof(float) * 4);

--- a/neo/renderer/DX12/dx12_raytracing.cpp
+++ b/neo/renderer/DX12/dx12_raytracing.cpp
@@ -338,10 +338,22 @@ namespace DX12Rendering {
 
 		m_lights[index].diffuseColor = color;
 
-		m_lights[index].specularColor.x = color.x * 2.0f;
-		m_lights[index].specularColor.y = color.y * 2.0f;
-		m_lights[index].specularColor.z = color.z * 2.0f;
-		m_lights[index].specularColor.w = color.w * 2.0f;
+		if (castsShadows)
+		{
+			// We will allow caluculation of the specular light.
+			m_lights[index].specularColor.x = color.x * 2.0f;
+			m_lights[index].specularColor.y = color.y * 2.0f;
+			m_lights[index].specularColor.z = color.z * 2.0f;
+			m_lights[index].specularColor.w = color.w * 2.0f;
+		}
+		else
+		{
+			// No calculated specualr light.
+			m_lights[index].specularColor.x = 0.0f;
+			m_lights[index].specularColor.y = 0.0f;
+			m_lights[index].specularColor.z = 0.0f;
+			m_lights[index].specularColor.w = 0.0f;
+		}
 
 		memcpy(&m_lights[index].projectionS, &lightProjection[0], sizeof(float) * 4);
 		memcpy(&m_lights[index].projectionT, &lightProjection[1], sizeof(float) * 4);

--- a/neo/renderer/DX12/dx12_raytracing.h
+++ b/neo/renderer/DX12/dx12_raytracing.h
@@ -114,14 +114,19 @@ namespace DX12Rendering {
 		XMFLOAT4 renderParameters[DX12Rendering::dxr_renderParm_t::COUNT];
 
 		UINT lightCount; // Note: This is no longer needed and can be changed if we would like.
-		float noiseOffset;
 		UINT diffuseTextureIndex;
 		UINT specularTextureIndex;
+		UINT materialTextureIndex;
 
 		UINT positionTextureIndex;
 		UINT flatNormalIndex;
 		UINT normalIndex;
 		UINT raysPerLight; // Number of shadow rays cast per light per pixel
+
+		float noiseOffset;
+		UINT pad0;
+		UINT pad1;
+		UINT pad2;
 	};
 
 	struct TopLevelAccelerationStructure;

--- a/neo/renderer/DX12/dx12_raytracing.h
+++ b/neo/renderer/DX12/dx12_raytracing.h
@@ -76,7 +76,8 @@ namespace DX12Rendering {
 		UINT pad2;
 		float emissiveRadius; // Radius used to calculate soft shadows.
 
-		XMFLOAT4 color;
+		XMFLOAT4 diffuseColor;
+		XMFLOAT4 specularColor; // The engine uses a different value for the two results. Usually specular is 2.0x
 
 		XMFLOAT4	center;
 

--- a/neo/renderer/DX12/dx12_raytracing.h
+++ b/neo/renderer/DX12/dx12_raytracing.h
@@ -70,10 +70,9 @@ namespace DX12Rendering {
 				bool isPointLight : 1;
 				bool isAmbientLight : 1;
 				bool isFogLight : 1;
-				bool flagPad[sizeof(UINT) - 2];
 			} flagValue;
 		};
-		UINT pad1;
+		float shadowStartDistance;
 		UINT pad2;
 		float emissiveRadius; // Radius used to calculate soft shadows.
 
@@ -124,7 +123,7 @@ namespace DX12Rendering {
 		UINT raysPerLight; // Number of shadow rays cast per light per pixel
 
 		float noiseOffset;
-		UINT pad0;
+		UINT flatTangentIndex;
 		UINT pad1;
 		UINT pad2;
 	};
@@ -151,7 +150,7 @@ public:
 	void Uniform4f(UINT index, const float* uniform);
 
 	void ResetLightList();
-	bool AddLight(const UINT index, const DXR_LIGHT_TYPE type, const DX12Rendering::TextureBuffer* falloffTexture, const DX12Rendering::TextureBuffer* projectionTexture, const UINT shadowMask, const XMFLOAT4& location, const XMFLOAT4& color, const XMFLOAT4* lightProjection, const XMFLOAT4& scissorWindow, bool castsShadows);
+	bool AddLight(const UINT index, const DXR_LIGHT_TYPE type, const DX12Rendering::TextureBuffer* falloffTexture, const DX12Rendering::TextureBuffer* projectionTexture, const UINT shadowMask, const XMFLOAT4& location, const XMFLOAT4& color, const XMFLOAT4* lightProjection, const XMFLOAT4& scissorWindow, bool castsShadows, float shadowStartDistance);
 	UINT GetLightMask(const UINT index);
 
 	void GenerateTLAS();

--- a/neo/renderer/DX12/dx12renderer.cpp
+++ b/neo/renderer/DX12/dx12renderer.cpp
@@ -1179,6 +1179,11 @@ DX12Rendering::BottomLevelAccelerationStructure* DX12Renderer::DXR_UpdateBLAS(co
 	if (!IsRaytracingEnabled()) {
 		return nullptr;
 	}
+
+	if (surfaceCount == 0)
+	{
+		return nullptr;
+	}
 	
 	DX12Rendering::WriteLock raytraceLock(m_raytracingLock);
 
@@ -1321,7 +1326,7 @@ DX12Rendering::BottomLevelAccelerationStructure* DX12Renderer::DXR_UpdateModelIn
 			continue;
 		}
 
-		if (!surf.shader->ReceivesLighting() || !surf.shader->LightCastsShadows()) // We're assuming all light receiving objects cast shadows in this model.
+		if (!surf.shader->LightCastsShadows())
 		{
 			// If we dont cast shadows, drop it.
 			continue;

--- a/neo/renderer/DX12/dx12renderer.cpp
+++ b/neo/renderer/DX12/dx12renderer.cpp
@@ -974,6 +974,8 @@ bool DX12Renderer::SetScreenParams(UINT width, UINT height, int fullscreen)
 			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::Position)->Resize(width, height);
 			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::Albedo)->Resize(width, height);
 			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::SpecularColor)->Resize(width, height);
+			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::Reflectivity)->Resize(width, height);
+			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::MaterialProperties)->Resize(width, height);
 
 			DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::GlobalIllumination)->Resize(width, height);
 
@@ -1390,7 +1392,7 @@ void DX12Renderer::DXR_SetRenderParams(DX12Rendering::dxr_renderParm_t param, co
 
 bool DX12Renderer::DXR_CastRays()
 {
-	if (r_useGli.GetBool())
+	if (false && r_useGli.GetBool()) //TODO: Re-enable when continuing global illumination.
 	{
 		m_raytracing->CastGlobalIlluminationRays(DX12Rendering::GetCurrentFrameIndex(), m_viewport, m_scissorRect);
 	}
@@ -1421,9 +1423,9 @@ bool DX12Renderer::DXR_CastRays()
 		specularMap->CopySurfaceToTexture(specularTexture, textureManager);
 
 		// Copy the global illumination data
-		auto globalIllumination = DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::GlobalIllumination);
+		/*auto globalIllumination = DX12Rendering::GetSurface(DX12Rendering::eRenderSurface::GlobalIllumination);
 		DX12Rendering::TextureBuffer* gliTexture = textureManager->GetGlobalTexture(DX12Rendering::eGlobalTexture::RAYTRACED_GLI);
-		globalIllumination->CopySurfaceToTexture(gliTexture, textureManager);
+		globalIllumination->CopySurfaceToTexture(gliTexture, textureManager);*/
 
 		// Wait for all copies to complete.
 		DX12Rendering::Commands::FenceValue fenceValue = DX12Rendering::Commands::GetCommandManager(DX12Rendering::Commands::COPY)->InsertFenceSignal();

--- a/neo/renderer/DX12/dx12renderer.h
+++ b/neo/renderer/DX12/dx12renderer.h
@@ -126,7 +126,7 @@ public:
 	bool DXR_BLASExists(const dxHandle_t id);
 	dxHandle_t DXR_GetBLASHandle(const idRenderModel* model);
 	DX12Rendering::BottomLevelAccelerationStructure* DXR_UpdateModelInBLAS(const idRenderModel* model);
-	DX12Rendering::BottomLevelAccelerationStructure* DXR_UpdateBLAS(const dxHandle_t id, const char* name, const bool isStatic, const size_t surfaceCount, DX12Rendering::RaytracingGeometryArgument* arguments);
+	DX12Rendering::BottomLevelAccelerationStructure* DXR_UpdateBLAS(const dxHandle_t id, const LPCWSTR name, const bool isStatic, const size_t surfaceCount, DX12Rendering::RaytracingGeometryArgument* arguments);
 	UINT DXR_UpdatePendingBLAS();
 
 	void DXR_RemoveModelInBLAS(const idRenderModel* model);

--- a/neo/renderer/DX12/dx12renderer.h
+++ b/neo/renderer/DX12/dx12renderer.h
@@ -189,7 +189,7 @@ private:
 	DX12Rendering::RenderRootSignature* m_rootSignature;
 	DX12Rendering::ComputeRootSignature* m_computeRootSignature;
 
-	XMFLOAT4 m_constantBuffer[57/* RENDERPARM_TOTAL */];
+	XMFLOAT4 m_constantBuffer[58/* RENDERPARM_TOTAL */];
 	UINT8* m_constantBufferGPUAddress[DX12_FRAME_COUNT];
 	ID3D12PipelineState* m_activePipelineState = nullptr;
 	UINT m_stencilRef = 0;

--- a/neo/renderer/RenderProgs.h
+++ b/neo/renderer/RenderProgs.h
@@ -118,6 +118,8 @@ enum renderParm_t {
 	RENDERPARM_ENABLE_SKINNING,
 	RENDERPARM_ALPHA_TEST,
 
+	RENDERPARAM_MATERIAL_PROPERTIES, // x = Roughness, y = Metallic, z = unused, w = unused
+
 	RENDERPARM_TOTAL,
 	RENDERPARM_USER = 128,
 };

--- a/neo/renderer/RenderWorld_portals.cpp
+++ b/neo/renderer/RenderWorld_portals.cpp
@@ -225,8 +225,12 @@ void idRenderWorldLocal::AddAreaViewEntities( int areaNum, const portalStack_t *
 			}
 		}
 
+		const renderEntity_t* renderEntity = &entity->parms;
+		bool isRaytracingEnabled = dxRenderer.IsRaytracingEnabled() && renderEntity->hModel != NULL &&
+			(renderEntity->hModel->ModelHasInteractingSurfaces() || renderEntity->hModel->ModelHasShadowCastingSurfaces());
+
 		// cull reference bounds
-		if ( CullEntityByPortals( entity, ps ) ) {
+		if (!isRaytracingEnabled && CullEntityByPortals( entity, ps ) ) {
 			// we are culled out through this portal chain, but it might
 			// still be visible through others
 			continue;
@@ -237,7 +241,7 @@ void idRenderWorldLocal::AddAreaViewEntities( int areaNum, const portalStack_t *
 		vEnt->modelRenderMatrix = entity->modelRenderMatrix;
 
 		// Check if we've created the needed BLAS
-		if (dxRenderer.IsRaytracingEnabled())
+		if (isRaytracingEnabled)
 		{
 			const renderEntity_t* renderEntity = &entity->parms;
 

--- a/neo/renderer/tr_local.h
+++ b/neo/renderer/tr_local.h
@@ -359,6 +359,9 @@ struct viewEntity_t {
 	// be linked to the lights or added to the drawsurf list in a serial code section
 	drawSurf_t *			drawSurfs;
 
+	// Used to calculate Dynamic bones later on.
+	drawSurf_t*				dynamicSurfaces;
+
 	// R_AddSingleModel will build a chain of parameters here to setup shadow volumes
 	staticShadowVolumeParms_t *		staticShadowVolumes;
 	dynamicShadowVolumeParms_t *	dynamicShadowVolumes;


### PR DESCRIPTION
Added the ability to add more offscreen objects to the Acceleration Structure. With this, texture samplers had to be fixed so that we're not adding more than 512 per frame. By hashing the descriptors, we were able to knock the count down to less than 10 samplers per frame.